### PR TITLE
Add GNU serial build and unit-test foundation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Preserve the verified upstream bytes in the vendored test-drive source.
+tests/vendor/test-drive-v0.6.1/** whitespace=-blank-at-eol,-blank-at-eof

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
-# Preserve the verified upstream bytes in the vendored test-drive source.
-tests/vendor/test-drive-v0.6.1/** whitespace=-blank-at-eol,-blank-at-eof
+# Preserve the verified upstream bytes in the vendored test-drive files.
+tests/vendor/test-drive-v0.6.1/LICENSE-Apache -text
+tests/vendor/test-drive-v0.6.1/LICENSE-MIT -text
+tests/vendor/test-drive-v0.6.1/src/testdrive.F90 -text whitespace=-blank-at-eol,-blank-at-eof

--- a/.github/workflows/makefile_tests.yml
+++ b/.github/workflows/makefile_tests.yml
@@ -27,6 +27,8 @@ jobs:
       - name: Check out XNet
         # actions/checkout v7.0.1
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Record toolchain
         run: |
@@ -56,6 +58,8 @@ jobs:
       - name: Check out XNet
         # actions/checkout v7.0.1
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          persist-credentials: false
 
       - name: Record toolchain
         run: |

--- a/.github/workflows/makefile_tests.yml
+++ b/.github/workflows/makefile_tests.yml
@@ -2,9 +2,9 @@ name: Baseline build and unit tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, codex/technical-modernization]
   pull_request:
-    branches: [main]
+    branches: [main, codex/technical-modernization]
 
 permissions:
   contents: read

--- a/.github/workflows/makefile_tests.yml
+++ b/.github/workflows/makefile_tests.yml
@@ -1,27 +1,69 @@
-name: Makefile tests
+name: Baseline build and unit tests
 
 on:
   push:
-    branches: [ "master" ]
+    branches: [main]
   pull_request:
-    branches: [ "master" ]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+defaults:
+  run:
+    shell: bash
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
+  serial-build-smoke:
+    name: serial-build-smoke
+    runs-on: ubuntu-24.04
+    timeout-minutes: 20
 
     steps:
-    - name: Checkout XNet
-      uses: actions/checkout@v3
+      - name: Check out XNet
+        # actions/checkout v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
 
-    - name: Setup environment
-      run: |
-        echo "XNET_DIR=${GITHUB_WORKSPACE}" >> ${GITHUB_ENV}
+      - name: Record toolchain
+        run: |
+          set -euo pipefail
+          gfortran --version
+          make --version
 
-    - name: Build
-      run: |
-        cd ${XNET_DIR}/source
-        make CMODE=DEBUG test_simple
-        make CMODE=DEBUG test_setup
-        make CMODE=DEBUG test_nse
+      - name: Build GNU serial debug baseline
+        run: |
+          set -euo pipefail
+          make -C source clean
+          make -C source -j2 \
+            CMODE=DEBUG PE_ENV=GNU \
+            MPI_MODE=OFF OPENMP_MODE=OFF GPU_MODE=OFF \
+            MATRIX_SOLVER=dense LAPACK_VER=NETLIB EOS=STARKILLER \
+            xnet net_setup xnse
+          test -x source/xnet
+          test -x source/net_setup
+          test -x source/xnse
+
+  serial-unit-tests:
+    name: serial-unit-tests
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out XNet
+        # actions/checkout v7.0.1
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+
+      - name: Record toolchain
+        run: |
+          set -euo pipefail
+          gfortran --version
+          make --version
+
+      - name: Run isolated public unit-test targets concurrently
+        run: |
+          set -euo pipefail
+          make -C source -j2 test_unit test_unit_selfcheck

--- a/.gitignore
+++ b/.gitignore
@@ -56,3 +56,6 @@ test/th*
 
 # runtime controls
 control*
+
+# isolated unit-test build
+/tests/build/

--- a/README.md
+++ b/README.md
@@ -22,5 +22,36 @@ Supernovae and Nucleosynthesis: An Investigation of the History of Matter, from 
 
 Someday, we'll make a list of publications using XNet, but that will wait...
 
+## Characterized GNU serial build
+
+The repository records a build-smoke configuration using GNU Fortran in debug
+mode with serial execution, the dense solver, vendored NETLIB, and the
+STARKILLER EOS. Run it from the repository root:
+
+```bash
+make -C source clean
+make -C source -j2 \
+  CMODE=DEBUG PE_ENV=GNU \
+  MPI_MODE=OFF OPENMP_MODE=OFF GPU_MODE=OFF \
+  MATRIX_SOLVER=dense LAPACK_VER=NETLIB EOS=STARKILLER \
+  xnet net_setup xnse
+```
+
+The production build is in-source, so clean before changing configuration.
+A successful build is compilation and link evidence for this exact
+configuration; it is not scientific validation or a support claim.
+
+## Dependency-light unit tests
+
+The isolated GNU serial unit-test targets are:
+
+```bash
+make -C source test_unit
+make -C source test_unit_selfcheck
+```
+
+The self-check deliberately exercises a failing fixture and verifies that the
+failure propagates through Make. See [the current architecture](doc/architecture.md)
+and [the validation plan](doc/validation-plan.md) for scope and limitations.
 
 

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -1,0 +1,59 @@
+# Current architecture
+
+This document describes the repository as it exists. It does not prescribe a
+future directory layout.
+
+## Repository areas
+
+- `source/` contains the production Fortran and GNU Make build.
+- `tools/LAPACK/` contains the vendored NETLIB subset used by the characterized
+  serial build.
+- `tools/starkiller-helmholtz/` supplies the STARKILLER EOS implementation and
+  table.
+- `test/` contains legacy problem inputs, network data, settings, and the
+  historical shell driver.
+- `tests/` contains the isolated serial unit-test harness.
+- `tools/` also contains network-building, thermodynamic, analysis, and Python
+  utilities.
+- `doc/` contains current guidance and historical scientific or solver
+  references.
+
+Production builds are currently in-source: objects, module files, and
+executables are written under `source/`. The Makefiles use `VPATH` to compile
+some dependencies from `tools/`. A clean rebuild is required when changing
+configuration.
+
+## Production layers
+
+| Area | Principal files | Role |
+| --- | --- | --- |
+| Foundation | `xnet_types`, `xnet_constants`, `xnet_util`, `xnet_timers`, `xnet_fd` | Kinds, constants, utilities, timing, Fermi-Dirac functions |
+| Configuration and state | `xnet_controls`, `xnet_conditions`, `xnet_abundances`, `xnet_data` | Runtime controls, thermodynamic state, abundances, species and reaction data |
+| Physics | `xnet_ffn`, `xnet_nnu`, `xnet_screening`, `xnet_flux`, `xnet_match`, `xnet_nse`, `xnet_eos_*` | Rates, screening, fluxes, reaction matching, NSE, and EOS selection |
+| Linear algebra | `xnet_linalg`, `xnet_jacobian_*` | BLAS/LAPACK dispatch and solver-specific Jacobians |
+| Integration | `xnet_integrate`, `xnet_integrate_be`, `xnet_integrate_bdf` | Cross sections, derivatives, timestep logic, and implicit solvers |
+| Driver and output | `xnet_evolve`, `xnet_output`, `model_input_ascii`, `net` | Zone evolution, diagnostics, input, and the `xnet` program |
+| Utilities | `net_setup`, `nse_slice` | Network preprocessing and the `xnse` program |
+| Portability | `xnet_parallel*`, `xnet_gpu`, `xnet_macros.fh`, vendor binding modules | Serial/MPI selection and accelerator interfaces |
+
+## Per-timestep flow
+
+`full_net()` in `xnet_evolve.F90` coordinates timestep selection and rate
+updates. `cross_sect()` updates EOS-dependent quantities, screening, partition
+functions, and weak/neutrino rates before producing `csect1` through
+`csect4`. `yderiv()` forms abundance derivatives. The selected BE or BDF
+integrator performs Newton iterations using the selected Jacobian and linear
+solver.
+
+## Build-time selection
+
+`source/Makefile.opt` exposes compiler environment, compile mode, EOS, matrix
+solver, CPU/GPU linear algebra, and parallel modes.
+`source/Makefile.internal` maps those choices to compiler flags, source
+dependencies, and libraries. `source/Makefile` chooses the serial parallel
+stubs or MPI wrappers, the EOS objects, and the solver-specific Jacobian.
+
+The presence of a selection in these files means only that the path is
+available. It does not establish that the path is characterized, scientifically
+validated, or supported. Recorded evidence is listed in
+[validation-plan.md](validation-plan.md).

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -36,15 +36,6 @@ configuration.
 | Utilities | `net_setup`, `nse_slice` | Network preprocessing and the `xnse` program |
 | Portability | `xnet_parallel*`, `xnet_gpu`, `xnet_macros.fh`, vendor binding modules | Serial/MPI selection and accelerator interfaces |
 
-## Per-timestep flow
-
-`full_net()` in `xnet_evolve.F90` coordinates timestep selection and rate
-updates. `cross_sect()` updates EOS-dependent quantities, screening, partition
-functions, and weak/neutrino rates before producing `csect1` through
-`csect4`. `yderiv()` forms abundance derivatives. The selected BE or BDF
-integrator performs Newton iterations using the selected Jacobian and linear
-solver.
-
 ## Build-time selection
 
 `source/Makefile.opt` exposes compiler environment, compile mode, EOS, matrix

--- a/doc/validation-plan.md
+++ b/doc/validation-plan.md
@@ -1,0 +1,87 @@
+# Validation plan
+
+## Purpose and evidence maturity
+
+XNet needs evidence that distinguishes “builds and runs” from “implements the
+intended science.” This inventory records current evidence without treating
+current output as a scientific reference answer or inventing tolerances.
+
+The maturity terms used here are:
+
+- **historical**: previously reported to work;
+- **available**: the code path exists;
+- **characterized**: reproduced in a recorded configuration;
+- **validated**: compared with an accepted scientific reference answer or
+  analytic result;
+- **supported**: the project commits to maintaining it.
+
+Evidence advances only when the exact configuration, command, result, and
+expected-result source are recorded.
+
+## Test categories
+
+1. **Runner self-tests** verify that the test mechanism returns reliable
+   process status.
+2. **Unit tests** exercise dependency-light routines and implementation
+   contracts.
+3. **Build smoke** verifies that named artifacts compile and link in an exact
+   configuration. It is not scientific validation.
+4. **Characterization tests** record reproducible current behavior without
+   claiming that behavior is correct.
+5. **Scientific validation tests** compare a scientific quantity with an
+   accepted analytic result, published benchmark, or independently verified
+   result.
+6. **Integration/regression tests** cover end-to-end behavior. A regression
+   baseline is authoritative only when its provenance and scientific review
+   are recorded.
+
+## Reference-answer requirements
+
+A scientific validation or regression proposal must identify the applicable
+configurations; the reference answer and its source; input provenance; units;
+the comparison quantity and norm; separately justified absolute and relative
+tolerances where applicable; sensitivity near zero; expected floating-point
+variation; runtime; and intended CI tier. Current output alone is not a source
+of correctness.
+
+## Evidence inventory
+
+| Item | Category | Maturity | Evidence | Configuration | Automation | Limitation |
+| --- | --- | --- | --- | --- | --- | --- |
+| Test-drive pass/fail propagation | Runner self-test | characterized | Expected process status; nested Make target observes failure | GNU Fortran, serial | `serial-unit-tests` | Runner behavior only |
+| `dp`, `sp`, and `i8` kind/storage contracts | Unit | characterized | `iso_fortran_env` and `storage_size` | GNU Fortran, serial | `serial-unit-tests` | Existing type model only |
+| Scalar/vector `safe_exp()` ordinary and clamped behavior | Unit | characterized | Intrinsic `exp`, clamp parameters, IEEE finite check, epsilon-scaled comparisons | GNU Fortran, serial | `serial-unit-tests` | Dependency-light routine behavior only |
+| Double-precision blank/tab numeric token parsing | Unit | characterized | Literal values after `replace_tabs()` and zero with `pos = 0` for exhausted input | GNU Fortran, serial | `serial-unit-tests` | Input-token behavior only |
+| ASCII case folding before abundance-name lookup | Characterization | characterized | Exact `Fe56` to `fe56` result from `string_lc()` | GNU Fortran, serial | `serial-unit-tests` | ASCII example only; not a locale, Unicode, file, or lookup-path claim |
+| Generated filename suffix formatting | Characterization | characterized | Literal one- and two-digit results from `name_ordered()` | GNU Fortran, serial | `serial-unit-tests` | Not arbitrary-width, path, filesystem, invalid-input, or compatibility validation |
+| `xnet`, `net_setup`, and `xnse` compile/link | Build smoke | characterized | Clean command and executable presence | GNU Fortran; debug; serial; dense; NETLIB; STARKILLER | `serial-build-smoke` | Build evidence only |
+| Legacy problem execution paths | Smoke/characterization | available | Inputs and scripts in `test/`; no tracked trusted results for exercised cases | Multiple historical configurations | Not a required gate | Historical use reported |
+| Legacy numerical comparisons | Regression | available | Mismatches do not propagate failure; reference provenance unavailable | Historical | Not a required gate | Not trusted as a scientific gate |
+
+These rows characterize only the exact configurations exercised by recorded
+local or CI runs. They are not scientific validation or support commitments.
+
+## Commands
+
+Run the characterized build from the repository root:
+
+```bash
+make -C source clean
+make -C source -j2 \
+  CMODE=DEBUG PE_ENV=GNU \
+  MPI_MODE=OFF OPENMP_MODE=OFF GPU_MODE=OFF \
+  MATRIX_SOLVER=dense LAPACK_VER=NETLIB EOS=STARKILLER \
+  xnet net_setup xnse
+```
+
+Run the isolated unit and runner self-check targets with:
+
+```bash
+make -C source test_unit
+make -C source test_unit_selfcheck
+```
+
+Each unit command begins from a clean dedicated directory under
+`tests/build/`, so the targets can run concurrently without sharing compiler
+artifacts. The self-check deliberately runs a failing fixture through a nested
+Make target and succeeds only when that target returns nonzero.

--- a/source/Makefile
+++ b/source/Makefile
@@ -91,10 +91,10 @@ test: test_serial test_heat test_setup test_nse
 .PHONY: clean test_unit test_unit_selfcheck
 
 test_unit:
-	$(MAKE) -C ../tests test FC="$(FC)"
+	$(MAKE) -C ../tests test
 
 test_unit_selfcheck:
-	$(MAKE) -C ../tests selfcheck FC="$(FC)"
+	$(MAKE) -C ../tests selfcheck
 
 test_serial: $(EXE)
 	@cd $(XNET_TEST_DIR) ; ln -sf ../tools/starkiller-helmholtz/helm_table.dat . ; ./test_xnet.sh ../source/xnet 12 53 54 55

--- a/source/Makefile
+++ b/source/Makefile
@@ -88,6 +88,14 @@ all: xnet_dense net_setup xnse
 
 test: test_serial test_heat test_setup test_nse
 
+.PHONY: clean test_unit test_unit_selfcheck
+
+test_unit:
+	$(MAKE) -C ../tests test FC="$(FC)"
+
+test_unit_selfcheck:
+	$(MAKE) -C ../tests selfcheck FC="$(FC)"
+
 test_serial: $(EXE)
 	@cd $(XNET_TEST_DIR) ; ln -sf ../tools/starkiller-helmholtz/helm_table.dat . ; ./test_xnet.sh ../source/xnet 12 53 54 55
 
@@ -199,6 +207,8 @@ $(SOLVER_OBJ_F): %.o: %.F
 
 clean:
 	rm -f core *.o *.oo *.mod *.lst *.cub *.ptx *.i *.T *.diag xref.db
+	rm -f xnet xnetd xnetd_mpi xnetm xnetm_mpi xnetp xnetp_mpi \
+	      net_setup xinab xnse xnse_mpi xnet_gpu xnet_gpu_mpi
 	rm -rf $(INLINE_DB) *.dSYM
 tar:
 	tar cvf net.tar ReadMe Changes Makefile *.f control th_const
@@ -226,7 +236,7 @@ xnet_integrate_be.o: xnet_abundances.o xnet_conditions.o xnet_controls.o xnet_da
 xnet_linalg.o: xnet_constants.o xnet_controls.o xnet_gpu.o xnet_types.o $(LAPACK_OBJ) $(GPU_OBJ)
 xnet_nnu.o: xnet_conditions.o xnet_controls.o xnet_types.o xnet_util.o
 xnet_nse.o: xnet_constants.o xnet_controls.o xnet_data.o xnet_timers.o xnet_types.o xnet_util.o $(EOS_OBJ) $(LAPACK_OBJ)
-xnet_output.o: xnet_abundances.o xnet_conditions.o xnet_controls.o xnet_data.o xnet_flux.o xnet_match.o xnet_parallel.o xnet_timers.o xnet_types.o
+xnet_output.o: xnet_abundances.o xnet_conditions.o xnet_controls.o xnet_data.o xnet_flux.o xnet_match.o $(MPI_OBJ) xnet_timers.o xnet_types.o
 xnet_preprocess.o: xnet_constants.o xnet_data.o xnet_types.o xnet_util.o $(MPI_OBJ)
 xnet_screening.o: xnet_abundances.o xnet_conditions.o xnet_constants.o xnet_controls.o xnet_data.o xnet_timers.o xnet_types.o $(EOS_OBJ)
 xnet_timers.o: xnet_types.o

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,0 +1,130 @@
+SHELL := /bin/bash
+
+FC = gfortran
+
+BUILD_ROOT := build
+BUILD_DIR ?= $(BUILD_ROOT)
+UNIT_BUILD_DIR := $(BUILD_ROOT)/unit
+SELFCHECK_BUILD_DIR := $(BUILD_ROOT)/selfcheck
+MOD_DIR := $(BUILD_DIR)/mod
+UNIT_EXE := $(BUILD_DIR)/unit_tests
+FAILURE_EXE := $(BUILD_DIR)/failure_fixture
+
+SOURCE_DIR := ../source
+VENDOR_DIR := vendor/test-drive-v0.6.1
+
+F90FLAGS = -g -Og -cpp -fimplicit-none -fallow-argument-mismatch \
+           -fdefault-real-8 -fdefault-double-8 -ffree-line-length-none
+COMPILE_FLAGS := $(F90FLAGS) -J$(MOD_DIR) -I$(MOD_DIR) -I$(SOURCE_DIR)
+
+PRODUCTION_OBJECTS := \
+	$(BUILD_DIR)/xnet_types.o \
+	$(BUILD_DIR)/xnet_parallel_stubs.o \
+	$(BUILD_DIR)/xnet_constants.o \
+	$(BUILD_DIR)/xnet_util.o
+
+TESTDRIVE_OBJECT := $(BUILD_DIR)/testdrive.o
+UNIT_OBJECTS := \
+	$(BUILD_DIR)/test_types.o \
+	$(BUILD_DIR)/test_safe_exp.o \
+	$(BUILD_DIR)/test_input_parsing.o \
+	$(BUILD_DIR)/test_name_ordered.o \
+	$(BUILD_DIR)/unit_test_main.o
+FAILURE_OBJECT := $(BUILD_DIR)/failure_fixture.o
+
+.PHONY: test run_unit selfcheck run_selfcheck failure_fixture_status \
+	clean clean_build
+
+test:
+	@$(MAKE) --no-print-directory clean_build BUILD_DIR="$(UNIT_BUILD_DIR)"
+	@$(MAKE) --no-print-directory run_unit BUILD_DIR="$(UNIT_BUILD_DIR)"
+
+run_unit: $(UNIT_EXE)
+	$(UNIT_EXE)
+
+selfcheck:
+	@$(MAKE) --no-print-directory clean_build BUILD_DIR="$(SELFCHECK_BUILD_DIR)"
+	@$(MAKE) --no-print-directory run_selfcheck BUILD_DIR="$(SELFCHECK_BUILD_DIR)"
+
+run_selfcheck: $(UNIT_EXE) $(FAILURE_EXE)
+	@$(UNIT_EXE)
+	@if $(FAILURE_EXE); then \
+	  echo "ERROR: the deliberate assertion failure returned zero"; \
+	  exit 1; \
+	else \
+	  echo "PASS: the deliberate assertion failure returned nonzero"; \
+	fi
+	@if $(MAKE) --no-print-directory failure_fixture_status; then \
+	  echo "ERROR: Make did not propagate the deliberate assertion failure"; \
+	  exit 1; \
+	else \
+	  echo "PASS: Make propagated the deliberate assertion failure"; \
+	fi
+
+failure_fixture_status: $(FAILURE_EXE)
+	$(FAILURE_EXE)
+
+$(UNIT_EXE): $(TESTDRIVE_OBJECT) $(PRODUCTION_OBJECTS) $(UNIT_OBJECTS)
+	$(FC) $(F90FLAGS) -o $@ $^
+
+$(FAILURE_EXE): $(TESTDRIVE_OBJECT) $(FAILURE_OBJECT)
+	$(FC) $(F90FLAGS) -o $@ $^
+
+$(BUILD_DIR) $(MOD_DIR):
+	mkdir -p $@
+
+$(BUILD_DIR)/testdrive.o: $(VENDOR_DIR)/src/testdrive.F90 | $(BUILD_DIR) $(MOD_DIR)
+	$(FC) $(COMPILE_FLAGS) -c $< -o $@
+
+$(BUILD_DIR)/xnet_types.o: $(SOURCE_DIR)/xnet_types.F90 | $(BUILD_DIR) $(MOD_DIR)
+	$(FC) $(COMPILE_FLAGS) -c $< -o $@
+
+$(BUILD_DIR)/xnet_parallel_stubs.o: $(SOURCE_DIR)/xnet_parallel_stubs.F90 \
+		$(BUILD_DIR)/xnet_types.o | $(BUILD_DIR) $(MOD_DIR)
+	$(FC) $(COMPILE_FLAGS) -c $< -o $@
+
+$(BUILD_DIR)/xnet_constants.o: $(SOURCE_DIR)/xnet_constants.F90 \
+		$(BUILD_DIR)/xnet_types.o | $(BUILD_DIR) $(MOD_DIR)
+	$(FC) $(COMPILE_FLAGS) -c $< -o $@
+
+$(BUILD_DIR)/xnet_util.o: $(SOURCE_DIR)/xnet_util.F90 \
+		$(BUILD_DIR)/xnet_types.o \
+		$(BUILD_DIR)/xnet_parallel_stubs.o \
+		$(BUILD_DIR)/xnet_constants.o | $(BUILD_DIR) $(MOD_DIR)
+	$(FC) $(COMPILE_FLAGS) -c $< -o $@
+
+$(BUILD_DIR)/test_types.o: unit/test_types.F90 \
+		$(TESTDRIVE_OBJECT) $(BUILD_DIR)/xnet_types.o | $(BUILD_DIR) $(MOD_DIR)
+	$(FC) $(COMPILE_FLAGS) -c $< -o $@
+
+$(BUILD_DIR)/test_safe_exp.o: unit/test_safe_exp.F90 \
+		$(TESTDRIVE_OBJECT) $(BUILD_DIR)/xnet_util.o | $(BUILD_DIR) $(MOD_DIR)
+	$(FC) $(COMPILE_FLAGS) -c $< -o $@
+
+$(BUILD_DIR)/test_input_parsing.o: unit/test_input_parsing.F90 \
+		$(TESTDRIVE_OBJECT) $(BUILD_DIR)/xnet_types.o \
+		$(BUILD_DIR)/xnet_util.o | $(BUILD_DIR) $(MOD_DIR)
+	$(FC) $(COMPILE_FLAGS) -c $< -o $@
+
+$(BUILD_DIR)/test_name_ordered.o: unit/test_name_ordered.F90 \
+		$(TESTDRIVE_OBJECT) $(BUILD_DIR)/xnet_util.o | $(BUILD_DIR) $(MOD_DIR)
+	$(FC) $(COMPILE_FLAGS) -c $< -o $@
+
+$(BUILD_DIR)/unit_test_main.o: unit/main.F90 \
+		$(TESTDRIVE_OBJECT) $(BUILD_DIR)/test_types.o \
+		$(BUILD_DIR)/test_safe_exp.o $(BUILD_DIR)/test_input_parsing.o \
+		$(BUILD_DIR)/test_name_ordered.o | $(BUILD_DIR) $(MOD_DIR)
+	$(FC) $(COMPILE_FLAGS) -c $< -o $@
+
+$(BUILD_DIR)/failure_fixture.o: selfcheck/failure_fixture.F90 \
+		$(TESTDRIVE_OBJECT) | $(BUILD_DIR) $(MOD_DIR)
+	$(FC) $(COMPILE_FLAGS) -c $< -o $@
+
+clean:
+	@$(MAKE) --no-print-directory clean_build BUILD_DIR="$(BUILD_ROOT)"
+	@$(MAKE) --no-print-directory clean_build BUILD_DIR="$(UNIT_BUILD_DIR)"
+	@$(MAKE) --no-print-directory clean_build BUILD_DIR="$(SELFCHECK_BUILD_DIR)"
+
+clean_build:
+	rm -f $(BUILD_DIR)/*.o $(BUILD_DIR)/unit_tests $(BUILD_DIR)/failure_fixture
+	rm -f $(MOD_DIR)/*.mod $(MOD_DIR)/*.smod

--- a/tests/selfcheck/failure_fixture.F90
+++ b/tests/selfcheck/failure_fixture.F90
@@ -1,0 +1,37 @@
+Module failure_fixture_suite
+  Use testdrive, Only: check, error_type, new_unittest, unittest_type
+  Implicit None
+  Private
+
+  Public :: collect_failure_fixture
+
+Contains
+
+  Subroutine collect_failure_fixture(tests)
+    Type(unittest_type), Allocatable, Intent(out) :: tests(:)
+
+    tests = [new_unittest("deliberate unexpected failure", deliberate_failure)]
+  End Subroutine collect_failure_fixture
+
+  Subroutine deliberate_failure(error)
+    Type(error_type), Allocatable, Intent(out) :: error
+
+    Call check(error, .False., &
+      "deliberate failure used only to verify process-status propagation")
+  End Subroutine deliberate_failure
+
+End Module failure_fixture_suite
+
+Program failure_fixture
+  Use, Intrinsic :: iso_fortran_env, Only: error_unit
+  Use failure_fixture_suite, Only: collect_failure_fixture
+  Use testdrive, Only: run_testsuite
+  Implicit None
+
+  Integer :: stat
+
+  stat = 0
+  Call run_testsuite(collect_failure_fixture, error_unit, stat)
+  ! Fall through with zero only when the runner misses the deliberate failure.
+  If ( stat /= 0 ) Error Stop 1
+End Program failure_fixture

--- a/tests/unit/main.F90
+++ b/tests/unit/main.F90
@@ -1,0 +1,30 @@
+Program unit_test_main
+  Use, Intrinsic :: iso_fortran_env, Only: error_unit
+  Use testdrive, Only: new_testsuite, run_testsuite, testsuite_type
+  Use test_input_parsing, Only: collect_input_parsing
+  Use test_name_ordered, Only: collect_name_ordered
+  Use test_safe_exp, Only: collect_safe_exp
+  Use test_types, Only: collect_types
+  Implicit None
+
+  Integer :: i, stat
+  Type(testsuite_type), Allocatable :: suites(:)
+
+  suites = [ &
+    new_testsuite("types", collect_types), &
+    new_testsuite("safe_exp", collect_safe_exp), &
+    new_testsuite("input parsing", collect_input_parsing), &
+    new_testsuite("generated filename suffixes", collect_name_ordered) &
+  ]
+
+  stat = 0
+  Do i = 1, Size(suites)
+    Write(error_unit, '("# Testing:", 1x, a)') suites(i)%name
+    Call run_testsuite(suites(i)%collect, error_unit, stat)
+  EndDo
+
+  If ( stat > 0 ) Then
+    Write(error_unit, '(i0, 1x, a)') stat, "test(s) failed"
+    Error Stop 1
+  EndIf
+End Program unit_test_main

--- a/tests/unit/test_input_parsing.F90
+++ b/tests/unit/test_input_parsing.F90
@@ -1,0 +1,59 @@
+Module test_input_parsing
+  Use testdrive, Only: check, error_type, new_unittest, unittest_type
+  Use xnet_types, Only: dp
+  Use xnet_util, Only: readnext, replace_tabs, string_lc
+  Implicit None
+  Private
+
+  Public :: collect_input_parsing
+
+Contains
+
+  Subroutine collect_input_parsing(tests)
+    Type(unittest_type), Allocatable, Intent(out) :: tests(:)
+
+    tests = [ &
+      new_unittest("tab and blank separated values", test_tab_and_blank_values), &
+      new_unittest("ASCII case folding", test_ascii_case_folding) &
+    ]
+  End Subroutine collect_input_parsing
+
+  Subroutine test_ascii_case_folding(error)
+    Type(error_type), Allocatable, Intent(out) :: error
+    Character(4) :: name
+
+    name = "Fe56"
+    Call string_lc(name)
+
+    Call check(error, name == "fe56", "ASCII case folding must lowercase F and preserve e56")
+  End Subroutine test_ascii_case_folding
+
+  Subroutine test_tab_and_blank_values(error)
+    Type(error_type), Allocatable, Intent(out) :: error
+    Character(64) :: line
+    Integer :: pos
+    Real(dp) :: value
+
+    line = "  1.25" // Achar(9) // " -2.5" // Achar(9) // "3.75"
+    Call replace_tabs(line)
+    pos = 1
+
+    Call readnext(line, pos, value)
+    Call check(error, value == 1.25_dp, "first token must be read after leading blanks")
+    If ( Allocated(error) ) Return
+
+    Call readnext(line, pos, value)
+    Call check(error, value == -2.5_dp, "second token must be read after a replaced tab")
+    If ( Allocated(error) ) Return
+
+    Call readnext(line, pos, value)
+    Call check(error, value == 3.75_dp, "third token must be read after a replaced tab")
+    If ( Allocated(error) ) Return
+
+    Call readnext(line, pos, value)
+    Call check(error, value == 0.0_dp, "missing token must return zero")
+    If ( Allocated(error) ) Return
+    Call check(error, pos == 0, "missing token must set position to zero")
+  End Subroutine test_tab_and_blank_values
+
+End Module test_input_parsing

--- a/tests/unit/test_name_ordered.F90
+++ b/tests/unit/test_name_ordered.F90
@@ -1,0 +1,35 @@
+Module test_name_ordered
+  Use testdrive, Only: check, error_type, new_unittest, unittest_type
+  Use xnet_util, Only: name_ordered
+  Implicit None
+  Private
+
+  Public :: collect_name_ordered
+
+Contains
+
+  Subroutine collect_name_ordered(tests)
+    Type(unittest_type), Allocatable, Intent(out) :: tests(:)
+
+    tests = [ &
+      new_unittest("generated filename suffixes", test_generated_filename_suffixes) &
+    ]
+  End Subroutine collect_name_ordered
+
+  Subroutine test_generated_filename_suffixes(error)
+    Type(error_type), Allocatable, Intent(out) :: error
+    Character(16) :: name
+
+    name = "zone"
+    Call name_ordered(name, 1, 1)
+    Call check(error, Trim(name) == "zone1", &
+      "nmax=1 must append the literal one-digit suffix")
+    If ( Allocated(error) ) Return
+
+    name = "diag"
+    Call name_ordered(name, 3, 12)
+    Call check(error, Trim(name) == "diag03", &
+      "nmax=12 must append the literal two-digit padded suffix")
+  End Subroutine test_generated_filename_suffixes
+
+End Module test_name_ordered

--- a/tests/unit/test_safe_exp.F90
+++ b/tests/unit/test_safe_exp.F90
@@ -1,0 +1,83 @@
+Module test_safe_exp
+  Use, Intrinsic :: ieee_arithmetic, Only: ieee_is_finite
+  Use testdrive, Only: check, error_type, new_unittest, unittest_type
+  Use xnet_types, Only: dp
+  Use xnet_util, Only: exp_max, exp_min, safe_exp
+  Implicit None
+  Private
+
+  Public :: collect_safe_exp
+
+Contains
+
+  Subroutine collect_safe_exp(tests)
+    Type(unittest_type), Allocatable, Intent(out) :: tests(:)
+
+    tests = [ &
+      new_unittest("ordinary scalar", test_ordinary_scalar), &
+      new_unittest("finite clamps", test_finite_clamps), &
+      new_unittest("scalar vector consistency", test_scalar_vector_consistency) &
+    ]
+  End Subroutine collect_safe_exp
+
+  Subroutine test_ordinary_scalar(error)
+    Type(error_type), Allocatable, Intent(out) :: error
+    Real(dp) :: actual, bound, expected, x
+
+    x = 1.25_dp
+    actual = safe_exp(x)
+    expected = Exp(x)
+    bound = 8.0_dp * Epsilon(1.0_dp) * Max(1.0_dp, Abs(expected))
+
+    Call check(error, Abs(actual - expected) <= bound, &
+      "safe_exp must agree with intrinsic exp in the ordinary range")
+  End Subroutine test_ordinary_scalar
+
+  Subroutine test_finite_clamps(error)
+    Type(error_type), Allocatable, Intent(out) :: error
+    Real(dp) :: actual_high, actual_low, bound, expected
+
+    actual_high = safe_exp(Huge(1.0_dp))
+    actual_low = safe_exp(-Huge(1.0_dp))
+
+    Call check(error, ieee_is_finite(actual_high), &
+      "positive extreme must remain finite")
+    If ( Allocated(error) ) Return
+    Call check(error, ieee_is_finite(actual_low), &
+      "negative extreme must remain finite")
+    If ( Allocated(error) ) Return
+
+    expected = Exp(exp_max)
+    bound = 16.0_dp * Epsilon(1.0_dp) * Abs(expected)
+    Call check(error, Abs(actual_high - expected) <= bound, &
+      "positive extreme must clamp at exp_max")
+    If ( Allocated(error) ) Return
+
+    expected = Exp(exp_min)
+    bound = 16.0_dp * Epsilon(1.0_dp) * Abs(expected)
+    Call check(error, Abs(actual_low - expected) <= bound, &
+      "negative extreme must clamp at exp_min")
+  End Subroutine test_finite_clamps
+
+  Subroutine test_scalar_vector_consistency(error)
+    Type(error_type), Allocatable, Intent(out) :: error
+    Integer :: i
+    Real(dp) :: bound, scalar_value
+    Real(dp) :: inputs(5), vector_values(5)
+
+    inputs = [ &
+      -Huge(1.0_dp), -2.0_dp, 0.0_dp, 3.0_dp, Huge(1.0_dp) &
+    ]
+    vector_values = safe_exp(inputs)
+
+    Do i = 1, Size(inputs)
+      scalar_value = safe_exp(inputs(i))
+      bound = 16.0_dp * Epsilon(1.0_dp) * &
+        Max(Abs(scalar_value), Tiny(1.0_dp))
+      Call check(error, Abs(vector_values(i) - scalar_value) <= bound, &
+        "scalar and vector safe_exp results must agree")
+      If ( Allocated(error) ) Return
+    EndDo
+  End Subroutine test_scalar_vector_consistency
+
+End Module test_safe_exp

--- a/tests/unit/test_types.F90
+++ b/tests/unit/test_types.F90
@@ -1,0 +1,41 @@
+Module test_types
+  Use, Intrinsic :: iso_fortran_env, Only: int64, real32, real64
+  Use testdrive, Only: check, error_type, new_unittest, unittest_type
+  Use xnet_types, Only: dp, i8, sp
+  Implicit None
+  Private
+
+  Public :: collect_types
+
+Contains
+
+  Subroutine collect_types(tests)
+    Type(unittest_type), Allocatable, Intent(out) :: tests(:)
+
+    tests = [ &
+      new_unittest("kind values", test_kind_values), &
+      new_unittest("storage sizes", test_storage_sizes) &
+    ]
+  End Subroutine collect_types
+
+  Subroutine test_kind_values(error)
+    Type(error_type), Allocatable, Intent(out) :: error
+
+    Call check(error, dp == real64, "dp must equal iso_fortran_env real64")
+    If ( Allocated(error) ) Return
+    Call check(error, sp == real32, "sp must equal iso_fortran_env real32")
+    If ( Allocated(error) ) Return
+    Call check(error, i8 == int64, "i8 must equal iso_fortran_env int64")
+  End Subroutine test_kind_values
+
+  Subroutine test_storage_sizes(error)
+    Type(error_type), Allocatable, Intent(out) :: error
+
+    Call check(error, Storage_Size(0.0_dp) == 64, "real(dp) must occupy 64 bits")
+    If ( Allocated(error) ) Return
+    Call check(error, Storage_Size(0.0_sp) == 32, "real(sp) must occupy 32 bits")
+    If ( Allocated(error) ) Return
+    Call check(error, Storage_Size(0_i8) == 64, "integer(i8) must occupy 64 bits")
+  End Subroutine test_storage_sizes
+
+End Module test_types

--- a/tests/vendor/test-drive-v0.6.1/LICENSE-Apache
+++ b/tests/vendor/test-drive-v0.6.1/LICENSE-Apache
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/tests/vendor/test-drive-v0.6.1/LICENSE-MIT
+++ b/tests/vendor/test-drive-v0.6.1/LICENSE-MIT
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2020-2021 Sebastian Ehlert
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/tests/vendor/test-drive-v0.6.1/PROVENANCE.md
+++ b/tests/vendor/test-drive-v0.6.1/PROVENANCE.md
@@ -1,0 +1,24 @@
+# test-drive provenance
+
+- Project: `fortran-lang/test-drive`
+- Release: `v0.6.1`
+- Release URL:
+  <https://github.com/fortran-lang/test-drive/releases/tag/v0.6.1>
+- Tag commit: `c506771aefd594e7e372240a8027b3fd06d61264`
+- Release archive: `test-drive-0.6.1.tar.xz`
+- Archive SHA-256:
+  `04452f0ca631bcb19c7cb937961457e17710d9c883deeee3c56e128e464b750f`
+- Vendored source SHA-256:
+  `97838a7042c2f9895c9e5fea01b7628247a0347be57ff742794513ee34a0510f`
+- Retrieved: 2026-07-29
+
+Included from the official release archive:
+
+- `src/testdrive.F90`
+- `LICENSE-MIT`
+- `LICENSE-Apache`
+
+The source is used only by the isolated serial unit-test build. To update it,
+open a focused dependency issue, verify the official release archive checksum
+and tag commit, review both license files, replace the vendored source, update
+the provenance record, and run the unit-test and failure-propagation commands.

--- a/tests/vendor/test-drive-v0.6.1/src/testdrive.F90
+++ b/tests/vendor/test-drive-v0.6.1/src/testdrive.F90
@@ -1,0 +1,2934 @@
+! This file is part of test-drive.
+! SPDX-Identifier: Apache-2.0 OR MIT
+!
+! Licensed under either of Apache License, Version 2.0 or MIT license
+! at your option; you may not use this file except in compliance with
+! the License.
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+!# Enable support for quadruple precision
+#ifndef WITH_QP
+#define WITH_QP 0
+#endif
+
+!# Enable support for extended double precision
+#ifndef WITH_XDP
+#define WITH_XDP 0
+#endif
+
+!# Enable ieee_is_nan for NaN detection
+#ifndef WITH_IEEE_IS_NAN
+#define WITH_IEEE_IS_NAN 0
+#endif
+
+!> Provides a light-weight procedural testing framework for Fortran projects.
+!>
+!> Testsuites are defined by a [[collect_interface]] returning a set of
+!> [[unittest_type]] objects. To create a new test use the [[new_unittest]]
+!> constructor, which requires a test identifier and a procedure with a
+!> [[test_interface]] compatible signature. The error status is communicated
+!> by the allocation status of an [[error_type]].
+!>
+!> The necessary boilerplate code to setup the test entry point is just
+!>
+!>```fortran
+!>program tester
+!>  use, intrinsic :: iso_fortran_env, only : error_unit
+!>  use testdrive, only : run_testsuite, new_testsuite, testsuite_type
+!>  use test_suite1, only : collect_suite1
+!>  use test_suite2, only : collect_suite2
+!>  implicit none
+!>  integer :: stat, is
+!>  type(testsuite_type), allocatable :: testsuites(:)
+!>  character(len=*), parameter :: fmt = '("#", *(1x, a))'
+!>
+!>  stat = 0
+!>
+!>  testsuites = [ &
+!>    new_testsuite("suite1", collect_suite1), &
+!>    new_testsuite("suite2", collect_suite2) &
+!>    ]
+!>
+!>  do is = 1, size(testsuites)
+!>    write(error_unit, fmt) "Testing:", testsuites(is)%name
+!>    call run_testsuite(testsuites(is)%collect, error_unit, stat)
+!>  end do
+!>
+!>  if (stat > 0) then
+!>    write(error_unit, '(i0, 1x, a)') stat, "test(s) failed!"
+!>    error stop
+!>  end if
+!>
+!>end program tester
+!>```
+!>
+!> Every test is defined in a separate module using a ``collect`` function, which
+!> is exported and added to the ``testsuites`` array in the test runner.
+!> All test have a simple interface with just an allocatable [[error_type]] as
+!> output to provide the test results.
+!>
+!>```fortran
+!>module test_suite1
+!>  use testdrive, only : new_unittest, unittest_type, error_type, check
+!>  implicit none
+!>  private
+!>
+!>  public :: collect_suite1
+!>
+!>contains
+!>
+!>!> Collect all exported unit tests
+!>subroutine collect_suite1(testsuite)
+!>  !> Collection of tests
+!>  type(unittest_type), allocatable, intent(out) :: testsuite(:)
+!>
+!>  testsuite = [ &
+!>    new_unittest("valid", test_valid), &
+!>    new_unittest("invalid", test_invalid, should_fail=.true.) &
+!>    ]
+!>
+!>end subroutine collect_suite1
+!>
+!>subroutine test_valid(error)
+!>  type(error_type), allocatable, intent(out) :: error
+!>  ! ...
+!>end subroutine test_valid
+!>
+!>subroutine test_invalid(error)
+!>  type(error_type), allocatable, intent(out) :: error
+!>  ! ...
+!>end subroutine test_invalid
+!>
+!>end module test_suite1
+!>```
+!>
+!> For an example setup checkout the ``test/`` directory in this project.
+module testdrive
+  use, intrinsic :: iso_fortran_env, only : error_unit
+  implicit none
+  private
+
+#if defined(__GFORTRAN__) && (__GNUC__ >= 15)
+! gfortran 15.1 finalization of derived types in this module can segfault
+#define TESTDRIVE_GFORTRAN_15_BROKEN_FINALIZATION 1
+#endif
+
+  public :: run_testsuite, run_selected, new_unittest, new_testsuite
+  public :: select_test, select_suite
+  public :: unittest_type, testsuite_type, error_type
+  public :: check, test_failed, skip_test
+  public :: test_interface, collect_interface
+  public :: get_argument, get_variable, to_string
+  public :: junit_output, junit_header
+  public :: init_color_output
+
+
+  !> Single precision real numbers
+  integer, parameter :: sp = selected_real_kind(6)
+
+  !> Double precision real numbers
+  integer, parameter :: dp = selected_real_kind(15)
+
+#if WITH_XDP
+  !> Extended double precision real numbers
+  integer, parameter :: xdp = selected_real_kind(18)
+#endif
+
+#if WITH_QP
+  !> Quadruple precision real numbers
+  integer, parameter :: qp = selected_real_kind(33)
+#endif
+
+  !> Char length for integers
+  integer, parameter :: i1 = selected_int_kind(2)
+
+  !> Short length for integers
+  integer, parameter :: i2 = selected_int_kind(4)
+
+  !> Length of default integers
+  integer, parameter :: i4 = selected_int_kind(9)
+
+  !> Long length for integers
+  integer, parameter :: i8 = selected_int_kind(18)
+
+  !> Error code for success
+  integer, parameter :: success = 0
+
+  !> Error code for failure
+  integer, parameter :: fatal = 1
+
+  !> Error code for skipped test
+  integer, parameter :: skipped = 77
+
+
+  !> Error message
+  type :: error_type
+
+    !> Error code
+    integer :: stat = success
+
+    !> Payload of the error
+    character(len=:), allocatable :: message
+
+  contains
+
+    !> Escalate uncaught errors
+    final :: escalate_error
+
+  end type error_type
+
+
+  interface check
+    module procedure :: check_stat
+    module procedure :: check_logical
+    module procedure :: check_float_sp
+    module procedure :: check_float_dp
+#if WITH_XDP
+    module procedure :: check_float_xdp
+#endif
+#if WITH_QP
+    module procedure :: check_float_qp
+#endif
+    module procedure :: check_float_exceptional_sp
+    module procedure :: check_float_exceptional_dp
+#if WITH_XDP
+    module procedure :: check_float_exceptional_xdp
+#endif
+#if WITH_QP
+    module procedure :: check_float_exceptional_qp
+#endif
+    module procedure :: check_complex_sp
+    module procedure :: check_complex_dp
+#if WITH_XDP
+    module procedure :: check_complex_xdp
+#endif
+#if WITH_QP
+    module procedure :: check_complex_qp
+#endif
+    module procedure :: check_complex_exceptional_sp
+    module procedure :: check_complex_exceptional_dp
+#if WITH_XDP
+    module procedure :: check_complex_exceptional_xdp
+#endif
+#if WITH_QP
+    module procedure :: check_complex_exceptional_qp
+#endif
+    module procedure :: check_float_absrel_sp
+    module procedure :: check_float_absrel_dp
+#if WITH_XDP
+    module procedure :: check_float_absrel_xdp
+#endif
+#if WITH_QP
+    module procedure :: check_float_absrel_qp
+#endif
+    module procedure :: check_complex_absrel_sp
+    module procedure :: check_complex_absrel_dp
+#if WITH_XDP
+    module procedure :: check_complex_absrel_xdp
+#endif
+#if WITH_QP
+    module procedure :: check_complex_absrel_qp
+#endif
+    module procedure :: check_int_i1
+    module procedure :: check_int_i2
+    module procedure :: check_int_i4
+    module procedure :: check_int_i8
+    module procedure :: check_bool
+    module procedure :: check_string
+  end interface check
+
+
+  interface to_string
+    module procedure :: integer_i1_to_string
+    module procedure :: integer_i2_to_string
+    module procedure :: integer_i4_to_string
+    module procedure :: integer_i8_to_string
+    module procedure :: real_sp_to_string
+    module procedure :: real_dp_to_string
+#if WITH_XDP
+    module procedure :: real_xdp_to_string
+#endif
+#if WITH_QP
+    module procedure :: real_qp_to_string
+#endif
+    module procedure :: complex_sp_to_string
+    module procedure :: complex_dp_to_string
+#if WITH_XDP
+    module procedure :: complex_xdp_to_string
+#endif
+#if WITH_QP
+    module procedure :: complex_qp_to_string
+#endif
+  end interface to_string
+
+
+  !> Check for not-a-number (NaN) values. Uses the IEEE intrinsic
+  !> `ieee_is_nan` when available, and falls back to a portable
+  !> comparison-based implementation (using `HUGE`/`ABS`) when IEEE
+  !> arithmetic is disabled.
+  interface is_nan
+    module procedure :: is_nan_sp
+    module procedure :: is_nan_dp
+#if WITH_XDP
+    module procedure :: is_nan_xdp
+#endif
+#if WITH_QP
+    module procedure :: is_nan_qp
+#endif
+  end interface is_nan
+
+
+  abstract interface
+    !> Entry point for tests
+    subroutine test_interface(error)
+      import :: error_type
+
+      !> Error handling
+      type(error_type), allocatable, intent(out) :: error
+
+    end subroutine test_interface
+  end interface
+
+
+  !> Declaration of a unit test
+  type :: unittest_type
+
+    !> Name of the test
+    character(len=:), allocatable :: name
+
+    !> Entry point of the test
+    procedure(test_interface), pointer, nopass :: test => null()
+
+    !> Whether test is supposed to fail
+    logical :: should_fail = .false.
+
+  contains
+
+#ifndef TESTDRIVE_GFORTRAN_15_BROKEN_FINALIZATION
+    !> Deallocate unittest's internal data
+    final :: destroy_unittest
+#endif
+
+  end type unittest_type
+
+
+  abstract interface
+    !> Collect all tests
+    subroutine collect_interface(testsuite)
+      import :: unittest_type
+#ifdef __NVCOMPILER_LLVM__
+      ! this is only an issue with nvhpc 25.9, possibly a bug in the compiler ! verify in next release
+      import :: test_interface
+#endif
+
+      !> Collection of tests
+      type(unittest_type), allocatable, intent(out) :: testsuite(:)
+
+    end subroutine collect_interface
+  end interface
+
+
+  !> Collection of unit tests
+  type :: testsuite_type
+
+    !> Name of the testsuite
+    character(len=:), allocatable :: name
+
+    !> Entry point of the test
+    procedure(collect_interface), pointer, nopass :: collect => null()
+
+  contains
+
+#ifndef TESTDRIVE_GFORTRAN_15_BROKEN_FINALIZATION
+    !> Deallocate testsuite's internal data
+    final :: destroy_testsuite
+#endif
+
+  end type testsuite_type
+
+
+  !> Output JUnit.xml for discovering unit tests by other tools
+  type :: junit_output
+    !> XML output string (initial block)
+    character(len=:), allocatable :: xml_start
+    !> XML output string (current block)
+    character(len=:), allocatable :: xml_block
+    !> XML output string (final block)
+    character(len=:), allocatable :: xml_final
+    !> Unique identifier
+    integer :: uid = 0
+    !> Timestamp
+    character(len=19) :: timestamp = '1970-01-01T00:00:00'
+    !> Hostname
+    character(len=:), allocatable :: hostname
+    !> Package name
+    character(len=:), allocatable :: package
+    !> Testsuite name
+    character(len=:), allocatable :: testsuite
+    !> Number of tests
+    integer :: tests = 0
+    !> Number of failures
+    integer :: failures = 0
+    !> Number of errors
+    integer :: errors = 0
+    !> Number of skipped tests
+    integer :: skipped = 0
+    !> Running time
+    real(sp) :: time = 0.0_sp
+  contains
+    final :: destroy_junit_output
+  end type junit_output
+
+
+  !> Container for terminal escape code
+  type :: color_code
+    !> Style descriptor
+    integer(i1) :: style = -1_i1
+    !> Background color descriptor
+    integer(i1) :: bg = -1_i1
+    !> Foreground color descriptor
+    integer(i1) :: fg = -1_i1
+  end type color_code
+
+  interface operator(+)
+    module procedure :: add_color
+  end interface operator(+)
+
+  interface operator(//)
+    module procedure :: concat_color_left
+    module procedure :: concat_color_right
+  end interface operator(//)
+
+
+  !> Colorizer class for handling colorful output in the terminal
+  type, public :: color_output
+
+    type(color_code) :: &
+      reset = color_code(), &
+      bold = color_code(), &
+      dim = color_code(), &
+      italic = color_code(), &
+      underline = color_code(), &
+      blink = color_code(), &
+      reverse = color_code(), &
+      hidden = color_code()
+
+    type(color_code) :: &
+      black = color_code(), &
+      red = color_code(), &
+      green = color_code(), &
+      yellow = color_code(), &
+      blue = color_code(), &
+      magenta = color_code(), &
+      cyan = color_code(), &
+      white = color_code()
+
+    type(color_code) :: &
+      bg_black = color_code(), &
+      bg_red = color_code(), &
+      bg_green = color_code(), &
+      bg_yellow = color_code(), &
+      bg_blue = color_code(), &
+      bg_magenta = color_code(), &
+      bg_cyan = color_code(), &
+      bg_white = color_code()
+  end type color_output
+
+  interface color_output
+    module procedure :: new_color_output
+  end interface color_output
+
+  type(color_output), protected :: color
+
+  character(len=*), parameter :: fmt = '(1x, *(1x, a))'
+  character(len=*), parameter :: newline = new_line("a")
+
+
+contains
+
+
+  !> Driver for testsuite
+  recursive subroutine run_testsuite(collect, unit, stat, parallel, junit)
+
+    !> Collect tests
+    procedure(collect_interface) :: collect
+
+    !> Unit for IO
+    integer, intent(in) :: unit
+
+    !> Number of failed tests
+    integer, intent(inout) :: stat
+
+    !> Run the tests in parallel
+    logical, intent(in), optional :: parallel
+
+    !> Produce junit output
+    type(junit_output), intent(inout), optional :: junit
+
+    type(unittest_type), allocatable :: testsuite(:)
+    integer :: it
+    logical :: parallel_
+
+    parallel_ = .true.
+    if(present(parallel)) parallel_ = parallel
+
+    call collect(testsuite)
+
+    call junit_push_suite(junit, "testdrive")
+
+    !$omp parallel do schedule(dynamic) shared(testsuite, unit) reduction(+:stat) &
+    !$omp if (parallel_)
+    do it = 1, size(testsuite)
+      !$omp critical(testdrive_testsuite)
+      write(unit, '(1x, 4(1x, a))') &
+        & "Starting", (color%blue)//testsuite(it)%name//color%reset, &
+        & color%dim//"..."//color%reset, &
+        & color%bold//"(" // color%cyan//to_string(it)//color%bold // &
+        & "/" // color%cyan//to_string(size(testsuite))//color%bold // ")"//color%reset
+      !$omp end critical(testdrive_testsuite)
+      call run_unittest(testsuite(it), unit, stat, junit)
+    end do
+
+    call junit_pop_suite(junit)
+
+  end subroutine run_testsuite
+
+
+  !> Driver for selective testing
+  recursive subroutine run_selected(collect, name, unit, stat, junit)
+
+    !> Collect tests
+    procedure(collect_interface) :: collect
+
+    !> Name of the selected test
+    character(len=*), intent(in) :: name
+
+    !> Unit for IO
+    integer, intent(in) :: unit
+
+    !> Number of failed tests
+    integer, intent(inout) :: stat
+
+    !> Produce junit output
+    type(junit_output), intent(inout), optional :: junit
+
+    type(unittest_type), allocatable :: testsuite(:)
+    integer :: it
+
+    call collect(testsuite)
+
+    call junit_push_suite(junit, "testdrive")
+
+    it = select_test(testsuite, name)
+
+    if (it > 0 .and. it <= size(testsuite)) then
+      call run_unittest(testsuite(it), unit, stat, junit)
+    else
+      write(unit, fmt) "Available tests:"
+      do it = 1, size(testsuite)
+        write(unit, fmt) "-", testsuite(it)%name
+      end do
+      stat = -huge(it)
+    end if
+
+    call junit_pop_suite(junit)
+
+  end subroutine run_selected
+
+
+  !> Run a selected unit test
+  recursive subroutine run_unittest(test, unit, stat, junit)
+
+    !> Unit test
+    type(unittest_type), intent(in) :: test
+
+    !> Unit for IO
+    integer, intent(in) :: unit
+
+    !> Number of failed tests
+    integer, intent(inout) :: stat
+
+    !> Produce junit output
+    type(junit_output), intent(inout), optional :: junit
+
+    type(error_type), allocatable :: error
+    character(len=:), allocatable :: message
+
+    call test%test(error)
+    if (.not.test_skipped(error)) then
+      if (allocated(error) .neqv. test%should_fail) stat = stat + 1
+    end if
+    call junit_push_test(junit, test, error, 0.0_sp)
+    call make_output(message, test, error)
+    !$omp critical(testdrive_testsuite)
+    write(unit, '(a)') message
+    !$omp end critical(testdrive_testsuite)
+    if (allocated(error)) then
+      call clear_error(error)
+    end if
+
+  end subroutine run_unittest
+
+
+  pure function test_skipped(error) result(is_skipped)
+
+    !> Error handling
+    type(error_type), intent(in), optional :: error
+
+    !> Test was skipped
+    logical :: is_skipped
+
+    is_skipped = .false.
+    if (present(error)) then
+      is_skipped = error%stat == skipped
+    end if
+
+  end function test_skipped
+
+
+  !> Create output message for test (this procedure is pure and therefore cannot launch tests)
+  pure subroutine make_output(output, test, error)
+
+    !> Output message for display
+    character(len=:), allocatable, intent(out) :: output
+
+    !> Unit test
+    type(unittest_type), intent(in) :: test
+
+    !> Error handling
+    type(error_type), intent(in), optional :: error
+
+    character(len=:), allocatable :: label
+    type(color_code) :: label_color
+
+    if (test_skipped(error)) then
+      label_color = color%yellow + color%bold
+      label = "SKIPPED"
+    else if (present(error) .neqv. test%should_fail) then
+      if (test%should_fail) then
+        label_color = color%magenta + color%bold
+        label = "UNEXPECTED PASS"
+      else
+        label_color = color%red + color%bold
+        label = "FAILED"
+      end if
+    else
+      if (test%should_fail) then
+        label_color = color%cyan + color%bold
+        label = "EXPECTED FAIL"
+      else
+        label_color = color%green + color%bold
+        label = "PASSED"
+      end if
+    end if
+    output = "       " // color%dim//"..."//color%reset // " " // &
+      & color%blue//test%name//color%reset // &
+      & " "//color%bold//"["//label_color//label//color%bold//"]"//color%reset
+    if (present(error)) then
+      output = output // newline // "  "//color%bold//"Message:"//color%reset//" " // error%message
+    end if
+  end subroutine make_output
+
+
+  !> Initialize output for JUnit.xml
+  pure subroutine junit_header(junit, package)
+
+    !> JUnit output
+    type(junit_output), intent(inout), optional :: junit
+
+    !> Package name
+    character(len=*), intent(in) :: package
+
+    if (.not.present(junit)) return
+
+    junit%xml_start = &
+      & '<?xml version="1.0" encoding="UTF-8"?>' // newline // &
+      & '<testsuites' // newline // &
+      & ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"' // newline // & 
+      & ' xsi:noNamespaceSchemaLocation="JUnit.xsd"' // newline // &
+      & '>' // newline
+    junit%xml_block = ''
+    junit%xml_final = &
+      & '</testsuites>'
+
+    junit%hostname = 'localhost'
+    junit%package = package
+
+  end subroutine junit_header
+
+  !> Register a test suite in JUnit.xml
+  subroutine junit_push_suite(junit, name)
+
+    !> JUnit output
+    type(junit_output), intent(inout), optional :: junit
+
+    !> Name of the test suite
+    character(len=*), intent(in) :: name
+
+    if (.not.present(junit)) return
+
+    junit%timestamp = get_timestamp()
+    junit%testsuite = name
+    junit%uid = junit%uid + 1
+
+  end subroutine junit_push_suite
+
+  !> Finalize a test suite in JUnit.xml
+  subroutine junit_pop_suite(junit)
+
+    !> JUnit output
+    type(junit_output), intent(inout), optional :: junit
+
+    if (.not.present(junit)) return
+
+    junit%xml_start = &
+      & junit%xml_start // &
+      & '  <testsuite' // newline // &
+      & '   name="'//junit%testsuite//'"' // newline // &
+      & '   package="'//junit%package//'"' // newline // &
+      & '   id="'//to_string(junit%uid)//'"' // newline // &
+      & '   timestamp="'//junit%timestamp//'"' // newline // &
+      & '   hostname="'//junit%hostname//'"' // newline // &
+      & '   tests="'//to_string(junit%tests)//'"' // newline // &
+      & '   failures="'//to_string(junit%failures)//'"' // newline // &
+      & '   errors="'//to_string(junit%errors)//'"' // newline // &
+      & '   skipped="'//to_string(junit%skipped)//'"' // newline // &
+      & '   time="'//to_string(junit%time)//'"' // newline // &
+      & '  >' // newline // &
+      & '  <properties>' // newline // &
+      & '  </properties>' // newline // &
+      & junit%xml_block // newline // &
+      & '  </testsuite>' // newline
+
+    junit%xml_block = ''
+    junit%tests = 0
+    junit%failures = 0
+    junit%errors = 0
+    junit%skipped = 0
+    junit%time = 0.0_sp
+
+    call junit_write(junit)
+
+  end subroutine junit_pop_suite
+
+  !> Register a new unit test
+  subroutine junit_push_test(junit, test, error, time)
+
+    !> JUnit output
+    type(junit_output), intent(inout), optional :: junit
+
+    !> Unit test
+    type(unittest_type), intent(in) :: test
+
+    !> Error handling
+    type(error_type), intent(in), optional :: error
+
+    !> Running time
+    real(sp), intent(in) :: time
+
+    if (.not.present(junit)) return
+
+    !$omp critical(testdrive_junit)
+    junit%tests = junit%tests + 1
+    junit%time = junit%time + time
+
+    junit%xml_block = &
+      & junit%xml_block // &
+      & '   <testcase' // newline // &
+      & '    name="'//test%name//'"' // newline // &
+      & '    classname="'//junit%testsuite//'"' // newline // &
+      & '    time="'//to_string(time)//'"' // newline // &
+      & '   >' // newline
+
+    if (test_skipped(error)) then
+      junit%xml_block = &
+        & junit%xml_block // &
+        & '    <skipped/>' // newline
+      junit%skipped = junit%skipped + 1
+    elseif (present(error)) then
+      if (test%should_fail) then
+        junit%xml_block = &
+          & junit%xml_block // &
+          & '    <system-out>' // newline // &
+          & '     "'//error%message//'"' // newline // &
+          & '    </system-out>' // newline
+      else
+        junit%xml_block = &
+          & junit%xml_block // &
+          & '    <failure' // newline // &
+          & '     message="'//error%message//'"' // newline // &
+          & '     type="AssertionError"' // newline // &
+          & '    />' // newline
+        junit%failures = junit%failures + 1
+      end if
+    else
+      if (test%should_fail) then
+        junit%xml_block = &
+          & junit%xml_block // &
+          & '    <failure' // newline // &
+          & '     message="Unexpected pass"' // newline // &
+          & '     type="AssertionError"' // newline // &
+          & '    />' // newline
+        junit%failures = junit%failures + 1
+      else
+        junit%xml_block = &
+          & junit%xml_block // &
+          & '    <system-out>' // newline // &
+          & '     "Test passed successfully"' // newline // &
+          & '    </system-out>' // newline
+      end if
+    end if
+
+    junit%xml_block = &
+      & junit%xml_block // &
+      & '   </testcase>' // newline   
+    !$omp end critical(testdrive_junit)
+
+  end subroutine junit_push_test
+
+
+  !> Write results to JUnit.xml
+  subroutine junit_write(junit)
+
+    !> JUnit output
+    type(junit_output), intent(inout), optional :: junit
+
+    integer :: io
+
+    if (.not.present(junit)) return
+    open( &
+      & newunit=io, &
+      & file='JUnit'//junit%package//'.xml', &
+      & status='replace', &
+      & action='write')
+    write(io, '(a)') junit%xml_start // junit%xml_final
+    close(io)
+
+  end subroutine junit_write
+
+
+  !> deallocate internal data of junit_output
+  subroutine destroy_junit_output(self)
+
+    !> JUnit output
+    type(junit_output), intent(inout) :: self
+
+    if (allocated(self%xml_start)) deallocate(self%xml_start)
+    if (allocated(self%xml_block)) deallocate(self%xml_block)
+    if (allocated(self%xml_final)) deallocate(self%xml_final)
+    if (allocated(self%hostname)) deallocate(self%hostname)
+    if (allocated(self%package)) deallocate(self%package)
+    if (allocated(self%testsuite)) deallocate(self%testsuite)
+
+  end subroutine destroy_junit_output
+
+
+  !> Create ISO 8601 formatted timestamp
+  function get_timestamp() result(timestamp)
+
+    !> ISO 8601 formatted timestamp
+    character(len=19) :: timestamp
+
+    character(len=8) :: date
+    character(len=10) :: time
+
+    call date_and_time(date=date, time=time)
+
+    timestamp = date(1:4) // "-" // date(5:6) // "-" // date(7:8) // "T" // &
+      & time(1:2) // ":" // time(3:4) // ":" // time(5:6)
+
+  end function get_timestamp
+
+
+  !> Select a unit test from all available tests
+  function select_test(tests, name) result(pos)
+
+    !> Name identifying the test suite
+    character(len=*), intent(in) :: name
+
+    !> Available unit tests
+    type(unittest_type) :: tests(:)
+
+    !> Selected test suite
+    integer :: pos
+
+    integer :: it
+
+    pos = 0
+    do it = 1, size(tests)
+      if (name == tests(it)%name) then
+        pos = it
+        exit
+      end if
+    end do
+
+  end function select_test
+
+
+  !> Select a test suite from all available suites
+  function select_suite(suites, name) result(pos)
+
+    !> Name identifying the test suite
+    character(len=*), intent(in) :: name
+
+    !> Available test suites
+    type(testsuite_type) :: suites(:)
+
+    !> Selected test suite
+    integer :: pos
+
+    integer :: it
+
+    pos = 0
+    do it = 1, size(suites)
+      if (name == suites(it)%name) then
+        pos = it
+        exit
+      end if
+    end do
+
+  end function select_suite
+
+
+  !> Register a new unit test
+  function new_unittest(name, test, should_fail) result(self)
+
+    !> Name of the test
+    character(len=*), intent(in) :: name
+
+    !> Entry point for the test
+    procedure(test_interface) :: test
+
+    !> Whether test is supposed to error or not
+    logical, intent(in), optional :: should_fail
+
+    !> Newly registered test
+    type(unittest_type) :: self
+
+    self%name = name
+    self%test => test
+    if (present(should_fail)) self%should_fail = should_fail
+
+  end function new_unittest
+
+
+  !> Finalize unit test
+  subroutine destroy_unittest(self)
+
+    !> unittest to destroy
+    type(unittest_type), intent(inout) :: self
+
+    if (allocated(self%name)) deallocate(self%name)
+    self%test => null()
+
+  end subroutine destroy_unittest
+
+
+  !> Register a new testsuite
+  function new_testsuite(name, collect) result(self)
+
+    !> Name of the testsuite
+    character(len=*), intent(in) :: name
+
+    !> Entry point to collect tests
+    procedure(collect_interface) :: collect
+
+    !> Newly registered testsuite
+    type(testsuite_type) :: self
+
+    self%name = name
+    self%collect => collect
+
+  end function new_testsuite
+
+
+  !> Finalize testsuite
+  subroutine destroy_testsuite(self)
+
+    !> testsuite to destroy
+    type(testsuite_type), intent(inout) :: self
+
+    if (allocated(self%name)) deallocate(self%name)
+    self%collect => null()
+
+  end subroutine destroy_testsuite
+
+
+  subroutine check_stat(error, stat, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Status of operation
+    integer, intent(in) :: stat
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    if (stat /= success) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, "Non-zero exit code encountered", more)
+      end if
+    end if
+
+  end subroutine check_stat
+
+
+  subroutine check_logical(error, expression, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Result of logical operator
+    logical, intent(in) :: expression
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    if (.not.expression) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, "Condition not fullfilled", more)
+      end if
+    end if
+
+  end subroutine check_logical
+
+
+  subroutine check_float_dp(error, actual, expected, message, more, thr, rel)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    real(dp), intent(in) :: actual
+
+    !> Expected floating point value
+    real(dp), intent(in) :: expected
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    !> Allowed threshold for matching floating point values
+    real(dp), intent(in), optional :: thr
+
+    !> Check for relative errors instead
+    logical, intent(in), optional :: rel
+
+    logical :: relative
+    real(dp) :: diff, threshold
+
+    call check(error, actual, message, more)
+    if (allocated(error)) return
+
+    if (present(thr)) then
+      threshold = thr
+    else
+      threshold = epsilon(expected)
+    end if
+
+    if (present(rel)) then
+      relative = rel
+    else
+      relative = .false.
+    end if
+
+    if (relative) then
+      diff = abs(actual - expected) / abs(expected)
+    else
+      diff = abs(actual - expected)
+    end if
+
+    if (diff > threshold) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        if (relative) then
+          call test_failed(error, &
+            "Floating point value mismatch", &
+            "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+            "(difference: "//to_string(int(diff*100))//"%)", &
+            more)
+        else
+          call test_failed(error, &
+            "Floating point value mismatch", &
+            "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+            "(difference: "//to_string(diff)//")", &
+            more)
+        end if
+      end if
+    end if
+
+  end subroutine check_float_dp
+
+
+  subroutine check_float_exceptional_dp(error, actual, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    real(dp), intent(in) :: actual
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    if (is_nan(actual)) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, "Exceptional value 'not a number' found", more)
+      end if
+    end if
+
+  end subroutine check_float_exceptional_dp
+
+
+  subroutine check_float_sp(error, actual, expected, message, more, thr, rel)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    real(sp), intent(in) :: actual
+
+    !> Expected floating point value
+    real(sp), intent(in) :: expected
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    !> Allowed threshold for matching floating point values
+    real(sp), intent(in), optional :: thr
+
+    !> Check for relative errors instead
+    logical, intent(in), optional :: rel
+
+    logical :: relative
+    real(sp) :: diff, threshold
+
+    call check(error, actual, message, more)
+    if (allocated(error)) return
+
+    if (present(thr)) then
+      threshold = thr
+    else
+      threshold = epsilon(expected)
+    end if
+
+    if (present(rel)) then
+      relative = rel
+    else
+      relative = .false.
+    end if
+
+    if (relative) then
+      diff = abs(actual - expected) / abs(expected)
+    else
+      diff = abs(actual - expected)
+    end if
+
+    if (diff > threshold) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        if (relative) then
+          call test_failed(error, &
+            "Floating point value mismatch", &
+            "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+            "(difference: "//to_string(int(diff*100))//"%)", &
+            more)
+        else
+          call test_failed(error, &
+            "Floating point value mismatch", &
+            "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+            "(difference: "//to_string(diff)//")", &
+            more)
+        end if
+      end if
+    end if
+
+  end subroutine check_float_sp
+
+
+  subroutine check_float_exceptional_sp(error, actual, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    real(sp), intent(in) :: actual
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    if (is_nan(actual)) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, "Exceptional value 'not a number' found", more)
+      end if
+    end if
+
+  end subroutine check_float_exceptional_sp
+
+
+#if WITH_XDP
+  subroutine check_float_xdp(error, actual, expected, message, more, thr, rel)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    real(xdp), intent(in) :: actual
+
+    !> Expected floating point value
+    real(xdp), intent(in) :: expected
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    !> Allowed threshold for matching floating point values
+    real(xdp), intent(in), optional :: thr
+
+    !> Check for relative errors instead
+    logical, intent(in), optional :: rel
+
+    logical :: relative
+    real(xdp) :: diff, threshold
+
+    call check(error, actual, message, more)
+    if (allocated(error)) return
+
+    if (present(thr)) then
+      threshold = thr
+    else
+      threshold = epsilon(expected)
+    end if
+
+    if (present(rel)) then
+      relative = rel
+    else
+      relative = .false.
+    end if
+
+    if (relative) then
+      diff = abs(actual - expected) / abs(expected)
+    else
+      diff = abs(actual - expected)
+    end if
+
+    if (diff > threshold) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        if (relative) then
+          call test_failed(error, &
+            "Floating point value mismatch", &
+            "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+            "(difference: "//to_string(int(diff*100))//"%)", &
+            more)
+        else
+          call test_failed(error, &
+            "Floating point value mismatch", &
+            "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+            "(difference: "//to_string(diff)//")", &
+            more)
+        end if
+      end if
+    end if
+
+  end subroutine check_float_xdp
+
+
+  subroutine check_float_exceptional_xdp(error, actual, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    real(xdp), intent(in) :: actual
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    if (is_nan(actual)) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, "Exceptional value 'not a number' found", more)
+      end if
+    end if
+
+  end subroutine check_float_exceptional_xdp
+#endif
+
+
+#if WITH_QP
+  subroutine check_float_qp(error, actual, expected, message, more, thr, rel)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    real(qp), intent(in) :: actual
+
+    !> Expected floating point value
+    real(qp), intent(in) :: expected
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    !> Allowed threshold for matching floating point values
+    real(qp), intent(in), optional :: thr
+
+    !> Check for relative errors instead
+    logical, intent(in), optional :: rel
+
+    logical :: relative
+    real(qp) :: diff, threshold
+
+    call check(error, actual, message, more)
+    if (allocated(error)) return
+
+    if (present(thr)) then
+      threshold = thr
+    else
+      threshold = epsilon(expected)
+    end if
+
+    if (present(rel)) then
+      relative = rel
+    else
+      relative = .false.
+    end if
+
+    if (relative) then
+      diff = abs(actual - expected) / abs(expected)
+    else
+      diff = abs(actual - expected)
+    end if
+
+    if (diff > threshold) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        if (relative) then
+          call test_failed(error, &
+            "Floating point value mismatch", &
+            "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+            "(difference: "//to_string(int(diff*100))//"%)", &
+            more)
+        else
+          call test_failed(error, &
+            "Floating point value mismatch", &
+            "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+            "(difference: "//to_string(diff)//")", &
+            more)
+        end if
+      end if
+    end if
+
+  end subroutine check_float_qp
+
+
+  subroutine check_float_exceptional_qp(error, actual, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    real(qp), intent(in) :: actual
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    if (is_nan(actual)) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, "Exceptional value 'not a number' found", more)
+      end if
+    end if
+
+  end subroutine check_float_exceptional_qp
+#endif
+
+
+  subroutine check_complex_dp(error, actual, expected, message, more, thr, rel)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    complex(dp), intent(in) :: actual
+
+    !> Expected floating point value
+    complex(dp), intent(in) :: expected
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    !> Allowed threshold for matching floating point values
+    real(dp), intent(in), optional :: thr
+
+    !> Check for relative errors instead
+    logical, intent(in), optional :: rel
+
+    logical :: relative
+    real(dp) :: diff, threshold
+
+    call check(error, actual, message, more)
+    if (allocated(error)) return
+
+    if (present(thr)) then
+      threshold = thr
+    else
+      threshold = epsilon(abs(expected))
+    end if
+
+    if (present(rel)) then
+      relative = rel
+    else
+      relative = .false.
+    end if
+
+    if (relative) then
+      diff = abs(actual - expected) / abs(expected)
+    else
+      diff = abs(actual - expected)
+    end if
+
+    if (diff > threshold) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        if (relative) then
+          call test_failed(error, &
+            "Floating point value mismatch", &
+            "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+            "(difference: "//to_string(int(diff*100))//"%)", &
+            more)
+        else
+          call test_failed(error, &
+            "Floating point value mismatch", &
+            "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+            "(difference: "//to_string(diff)//")", &
+            more)
+        end if
+      end if
+    end if
+
+  end subroutine check_complex_dp
+
+
+  subroutine check_complex_exceptional_dp(error, actual, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    complex(dp), intent(in) :: actual
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    if (is_nan(real(actual)) .or. is_nan(aimag(actual))) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, "Exceptional value 'not a number' found", more)
+      end if
+    end if
+
+  end subroutine check_complex_exceptional_dp
+
+
+  subroutine check_complex_sp(error, actual, expected, message, more, thr, rel)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    complex(sp), intent(in) :: actual
+
+    !> Expected floating point value
+    complex(sp), intent(in) :: expected
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    !> Allowed threshold for matching floating point values
+    real(sp), intent(in), optional :: thr
+
+    !> Check for relative errors instead
+    logical, intent(in), optional :: rel
+
+    logical :: relative
+    real(sp) :: diff, threshold
+
+    call check(error, actual, message, more)
+    if (allocated(error)) return
+
+    if (present(thr)) then
+      threshold = thr
+    else
+      threshold = epsilon(abs(expected))
+    end if
+
+    if (present(rel)) then
+      relative = rel
+    else
+      relative = .false.
+    end if
+
+    if (relative) then
+      diff = abs(actual - expected) / abs(expected)
+    else
+      diff = abs(actual - expected)
+    end if
+
+    if (diff > threshold) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        if (relative) then
+          call test_failed(error, &
+            "Floating point value mismatch", &
+            "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+            "(difference: "//to_string(int(diff*100))//"%)", &
+            more)
+        else
+          call test_failed(error, &
+            "Floating point value mismatch", &
+            "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+            "(difference: "//to_string(diff)//")", &
+            more)
+        end if
+      end if
+    end if
+
+  end subroutine check_complex_sp
+
+
+  subroutine check_complex_exceptional_sp(error, actual, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    complex(sp), intent(in) :: actual
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    if (is_nan(real(actual)) .or. is_nan(aimag(actual))) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, "Exceptional value 'not a number' found", more)
+      end if
+    end if
+
+  end subroutine check_complex_exceptional_sp
+
+
+#if WITH_XDP
+  subroutine check_complex_xdp(error, actual, expected, message, more, thr, rel)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    complex(xdp), intent(in) :: actual
+
+    !> Expected floating point value
+    complex(xdp), intent(in) :: expected
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    !> Allowed threshold for matching floating point values
+    real(xdp), intent(in), optional :: thr
+
+    !> Check for relative errors instead
+    logical, intent(in), optional :: rel
+
+    logical :: relative
+    real(xdp) :: diff, threshold
+
+    call check(error, actual, message, more)
+    if (allocated(error)) return
+
+    if (present(thr)) then
+      threshold = thr
+    else
+      threshold = epsilon(abs(expected))
+    end if
+
+    if (present(rel)) then
+      relative = rel
+    else
+      relative = .false.
+    end if
+
+    if (relative) then
+      diff = abs(actual - expected) / abs(expected)
+    else
+      diff = abs(actual - expected)
+    end if
+
+    if (diff > threshold) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        if (relative) then
+          call test_failed(error, &
+            "Floating point value mismatch", &
+            "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+            "(difference: "//to_string(int(diff*100))//"%)", &
+            more)
+        else
+          call test_failed(error, &
+            "Floating point value mismatch", &
+            "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+            "(difference: "//to_string(diff)//")", &
+            more)
+        end if
+      end if
+    end if
+
+  end subroutine check_complex_xdp
+
+
+  subroutine check_complex_exceptional_xdp(error, actual, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    complex(xdp), intent(in) :: actual
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    if (is_nan(real(actual)) .or. is_nan(aimag(actual))) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, "Exceptional value 'not a number' found", more)
+      end if
+    end if
+
+  end subroutine check_complex_exceptional_xdp
+#endif
+
+
+#if WITH_QP
+  subroutine check_complex_qp(error, actual, expected, message, more, thr, rel)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    complex(qp), intent(in) :: actual
+
+    !> Expected floating point value
+    complex(qp), intent(in) :: expected
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    !> Allowed threshold for matching floating point values
+    real(qp), intent(in), optional :: thr
+
+    !> Check for relative errors instead
+    logical, intent(in), optional :: rel
+
+    logical :: relative
+    real(qp) :: diff, threshold
+
+    call check(error, actual, message, more)
+    if (allocated(error)) return
+
+    if (present(thr)) then
+      threshold = thr
+    else
+      threshold = epsilon(abs(expected))
+    end if
+
+    if (present(rel)) then
+      relative = rel
+    else
+      relative = .false.
+    end if
+
+    if (relative) then
+      diff = abs(actual - expected) / abs(expected)
+    else
+      diff = abs(actual - expected)
+    end if
+
+    if (diff > threshold) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        if (relative) then
+          call test_failed(error, &
+            "Floating point value mismatch", &
+            "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+            "(difference: "//to_string(int(diff*100))//"%)", &
+            more)
+        else
+          call test_failed(error, &
+            "Floating point value mismatch", &
+            "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+            "(difference: "//to_string(diff)//")", &
+            more)
+        end if
+      end if
+    end if
+
+  end subroutine check_complex_qp
+
+
+  subroutine check_complex_exceptional_qp(error, actual, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    complex(qp), intent(in) :: actual
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    if (is_nan(real(actual)) .or. is_nan(aimag(actual))) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, "Exceptional value 'not a number' found", more)
+      end if
+    end if
+
+  end subroutine check_complex_exceptional_qp
+#endif
+
+
+  subroutine check_float_absrel_dp(error, actual, expected, thr_abs, thr_rel, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    real(dp), intent(in) :: actual
+
+    !> Expected floating point value
+    real(dp), intent(in) :: expected
+
+    !> Absolute threshold for matching floating point values
+    real(dp), intent(in) :: thr_abs
+
+    !> Relative threshold for matching floating point values
+    real(dp), intent(in) :: thr_rel
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    real(dp) :: diff, threshold
+
+    call check(error, actual, message, more)
+    if (allocated(error)) return
+
+    diff = abs(actual - expected)
+    threshold = max(thr_abs, abs(thr_rel * expected))
+
+    if (diff > threshold) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, &
+          "Floating point value mismatch", &
+          "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+          "(difference: "//to_string(diff)//")", &
+          more)
+      end if
+    end if
+
+  end subroutine check_float_absrel_dp
+
+
+  subroutine check_float_absrel_sp(error, actual, expected, thr_abs, thr_rel, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    real(sp), intent(in) :: actual
+
+    !> Expected floating point value
+    real(sp), intent(in) :: expected
+
+    !> Absolute threshold for matching floating point values
+    real(sp), intent(in) :: thr_abs
+
+    !> Relative threshold for matching floating point values
+    real(sp), intent(in) :: thr_rel
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    real(sp) :: diff, threshold
+
+    call check(error, actual, message, more)
+    if (allocated(error)) return
+
+    diff = abs(actual - expected)
+    threshold = max(thr_abs, abs(thr_rel * expected))
+
+    if (diff > threshold) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, &
+          "Floating point value mismatch", &
+          "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+          "(difference: "//to_string(diff)//")", &
+          more)
+      end if
+    end if
+
+  end subroutine check_float_absrel_sp
+
+
+#if WITH_XDP
+  subroutine check_float_absrel_xdp(error, actual, expected, thr_abs, thr_rel, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    real(xdp), intent(in) :: actual
+
+    !> Expected floating point value
+    real(xdp), intent(in) :: expected
+
+    !> Absolute threshold for matching floating point values
+    real(xdp), intent(in) :: thr_abs
+
+    !> Relative threshold for matching floating point values
+    real(xdp), intent(in) :: thr_rel
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    real(xdp) :: diff, threshold
+
+    call check(error, actual, message, more)
+    if (allocated(error)) return
+
+    diff = abs(actual - expected)
+    threshold = max(thr_abs, abs(thr_rel * expected))
+
+    if (diff > threshold) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, &
+          "Floating point value mismatch", &
+          "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+          "(difference: "//to_string(diff)//")", &
+          more)
+      end if
+    end if
+
+  end subroutine check_float_absrel_xdp
+#endif
+
+
+#if WITH_QP
+  subroutine check_float_absrel_qp(error, actual, expected, thr_abs, thr_rel, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    real(qp), intent(in) :: actual
+
+    !> Expected floating point value
+    real(qp), intent(in) :: expected
+
+    !> Absolute threshold for matching floating point values
+    real(qp), intent(in) :: thr_abs
+
+    !> Relative threshold for matching floating point values
+    real(qp), intent(in) :: thr_rel
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    real(qp) :: diff, threshold
+
+    call check(error, actual, message, more)
+    if (allocated(error)) return
+
+    diff = abs(actual - expected)
+    threshold = max(thr_abs, abs(thr_rel * expected))
+
+    if (diff > threshold) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, &
+          "Floating point value mismatch", &
+          "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+          "(difference: "//to_string(diff)//")", &
+          more)
+      end if
+    end if
+
+  end subroutine check_float_absrel_qp
+#endif
+
+
+  subroutine check_complex_absrel_dp(error, actual, expected, thr_abs, thr_rel, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    complex(dp), intent(in) :: actual
+
+    !> Expected floating point value
+    complex(dp), intent(in) :: expected
+
+    !> Absolute threshold for matching floating point values
+    real(dp), intent(in) :: thr_abs
+
+    !> Relative threshold for matching floating point values
+    real(dp), intent(in) :: thr_rel
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    real(dp) :: diff, threshold
+
+    call check(error, actual, message, more)
+    if (allocated(error)) return
+
+    diff = abs(actual - expected)
+    threshold = max(thr_abs, abs(thr_rel * expected))
+
+    if (diff > threshold) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, &
+          "Floating point value mismatch", &
+          "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+          "(difference: "//to_string(diff)//")", &
+          more)
+      end if
+    end if
+
+  end subroutine check_complex_absrel_dp
+
+
+  subroutine check_complex_absrel_sp(error, actual, expected, thr_abs, thr_rel, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    complex(sp), intent(in) :: actual
+
+    !> Expected floating point value
+    complex(sp), intent(in) :: expected
+
+    !> Absolute threshold for matching floating point values
+    real(sp), intent(in) :: thr_abs
+
+    !> Relative threshold for matching floating point values
+    real(sp), intent(in) :: thr_rel
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    real(sp) :: diff, threshold
+
+    call check(error, actual, message, more)
+    if (allocated(error)) return
+
+    diff = abs(actual - expected)
+    threshold = max(thr_abs, abs(thr_rel * expected))
+
+    if (diff > threshold) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, &
+          "Floating point value mismatch", &
+          "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+          "(difference: "//to_string(diff)//")", &
+          more)
+      end if
+    end if
+
+  end subroutine check_complex_absrel_sp
+
+
+#if WITH_XDP
+  subroutine check_complex_absrel_xdp(error, actual, expected, thr_abs, thr_rel, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    complex(xdp), intent(in) :: actual
+
+    !> Expected floating point value
+    complex(xdp), intent(in) :: expected
+
+    !> Absolute threshold for matching floating point values
+    real(xdp), intent(in) :: thr_abs
+
+    !> Relative threshold for matching floating point values
+    real(xdp), intent(in) :: thr_rel
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    real(xdp) :: diff, threshold
+
+    call check(error, actual, message, more)
+    if (allocated(error)) return
+
+    diff = abs(actual - expected)
+    threshold = max(thr_abs, abs(thr_rel * expected))
+
+    if (diff > threshold) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, &
+          "Floating point value mismatch", &
+          "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+          "(difference: "//to_string(diff)//")", &
+          more)
+      end if
+    end if
+
+  end subroutine check_complex_absrel_xdp
+#endif
+
+
+#if WITH_QP
+  subroutine check_complex_absrel_qp(error, actual, expected, thr_abs, thr_rel, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found floating point value
+    complex(qp), intent(in) :: actual
+
+    !> Expected floating point value
+    complex(qp), intent(in) :: expected
+
+    !> Absolute threshold for matching floating point values
+    real(qp), intent(in) :: thr_abs
+
+    !> Relative threshold for matching floating point values
+    real(qp), intent(in) :: thr_rel
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    real(qp) :: diff, threshold
+
+    call check(error, actual, message, more)
+    if (allocated(error)) return
+
+    diff = abs(actual - expected)
+    threshold = max(thr_abs, abs(thr_rel * expected))
+
+    if (diff > threshold) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, &
+          "Floating point value mismatch", &
+          "expected "//to_string(expected)//" but got "//to_string(actual)//" "//&
+          "(difference: "//to_string(diff)//")", &
+          more)
+      end if
+    end if
+
+  end subroutine check_complex_absrel_qp
+#endif
+
+
+  subroutine check_int_i1(error, actual, expected, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found integer value
+    integer(i1), intent(in) :: actual
+
+    !> Expected integer value
+    integer(i1), intent(in) :: expected
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    if (expected /= actual) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, &
+          "Integer value mismatch", &
+          "expected "//to_string(expected)//" but got "//to_string(actual), &
+          more)
+      end if
+    end if
+
+  end subroutine check_int_i1
+
+
+  subroutine check_int_i2(error, actual, expected, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found integer value
+    integer(i2), intent(in) :: actual
+
+    !> Expected integer value
+    integer(i2), intent(in) :: expected
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    if (expected /= actual) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, &
+          "Integer value mismatch", &
+          "expected "//to_string(expected)//" but got "//to_string(actual), &
+          more)
+      end if
+    end if
+
+  end subroutine check_int_i2
+
+
+  subroutine check_int_i4(error, actual, expected, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found integer value
+    integer(i4), intent(in) :: actual
+
+    !> Expected integer value
+    integer(i4), intent(in) :: expected
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    if (expected /= actual) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, &
+          "Integer value mismatch", &
+          "expected "//to_string(expected)//" but got "//to_string(actual), &
+          more)
+      end if
+    end if
+
+  end subroutine check_int_i4
+
+
+  subroutine check_int_i8(error, actual, expected, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found integer value
+    integer(i8), intent(in) :: actual
+
+    !> Expected integer value
+    integer(i8), intent(in) :: expected
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    if (expected /= actual) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, &
+          "Integer value mismatch", &
+          "expected "//to_string(expected)//" but got "//to_string(actual), &
+          more)
+      end if
+    end if
+
+  end subroutine check_int_i8
+
+
+  subroutine check_bool(error, actual, expected, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found boolean value
+    logical, intent(in) :: actual
+
+    !> Expected boolean value
+    logical, intent(in) :: expected
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    if (expected .neqv. actual) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, &
+          "Logical value mismatch", &
+          "expected "//merge("T", "F", expected)//" but got "//merge("T", "F", actual), &
+          more)
+      end if
+    end if
+
+  end subroutine check_bool
+
+
+  subroutine check_string(error, actual, expected, message, more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> Found boolean value
+    character(len=*), intent(in) :: actual
+
+    !> Expected boolean value
+    character(len=*), intent(in) :: expected
+
+    !> A detailed message describing the error
+    character(len=*), intent(in), optional :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    if (expected /= actual) then
+      if (present(message)) then
+        call test_failed(error, message, more)
+      else
+        call test_failed(error, &
+          "Character value mismatch", &
+          "expected '"//expected//"' but got '"//actual//"'", &
+          more)
+      end if
+    end if
+
+  end subroutine check_string
+
+
+  subroutine test_failed(error, message, more, and_more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> A detailed message describing the error
+    character(len=*), intent(in) :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: and_more
+
+    character(len=*), parameter :: skip = newline // repeat(" ", 11)
+
+    allocate(error)
+    error%stat = fatal
+
+    error%message = message
+    if (present(more)) then
+      error%message = error%message // skip // more
+    end if
+    if (present(and_more)) then
+      error%message = error%message // skip // and_more
+    end if
+
+  end subroutine test_failed
+
+
+  !> A test is skipped because certain requirements are not met to run the actual test
+  subroutine skip_test(error, message, more, and_more)
+
+    !> Error handling
+    type(error_type), allocatable, intent(out) :: error
+
+    !> A detailed message describing the error
+    character(len=*), intent(in) :: message
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: more
+
+    !> Another line of error message
+    character(len=*), intent(in), optional :: and_more
+
+    call test_failed(error, message, more, and_more)
+    error%stat = skipped
+
+  end subroutine skip_test
+
+
+  !> Obtain the command line argument at a given index
+  subroutine get_argument(idx, arg)
+
+    !> Index of command line argument, range [0:command_argument_count()]
+    integer, intent(in) :: idx
+
+    !> Command line argument
+    character(len=:), allocatable, intent(out) :: arg
+
+    integer :: length, stat
+
+    call get_command_argument(idx, length=length, status=stat)
+    if (stat /= success) return
+
+    allocate(character(len=length) :: arg, stat=stat)
+    if (stat /= success) return
+
+    if (length > 0) then
+      call get_command_argument(idx, arg, status=stat)
+      if (stat /= success) deallocate(arg)
+    end if
+
+  end subroutine get_argument
+
+
+  !> Obtain the value of an environment variable
+  subroutine get_variable(var, val)
+
+    !> Name of variable
+    character(len=*), intent(in) :: var
+
+    !> Value of variable
+    character(len=:), allocatable, intent(out) :: val
+
+    integer :: length, stat
+
+    call get_environment_variable(var, length=length, status=stat)
+    if (stat /= success) return
+
+    allocate(character(len=length) :: val, stat=stat)
+    if (stat /= success) return
+
+    if (length > 0) then
+      call get_environment_variable(var, val, status=stat)
+      if (stat /= success) deallocate(val)
+    end if
+
+  end subroutine get_variable
+
+
+  pure function integer_i1_to_string(val) result(string)
+    integer, parameter :: ik = i1
+    !> Integer value to create string from
+    integer(ik), intent(in) :: val
+    !> String representation of integer
+    character(len=:), allocatable :: string
+
+    integer, parameter :: buffer_len = range(val)+2
+    character(len=buffer_len) :: buffer
+    integer :: pos
+    integer(ik) :: n
+    character(len=1), parameter :: numbers(-9:0) = &
+      ["9", "8", "7", "6", "5", "4", "3", "2", "1", "0"]
+
+    if (val == 0_ik) then
+      string = numbers(0)
+      return
+    end if
+
+    n = sign(val, -1_ik)
+    buffer = ""
+    pos = buffer_len + 1
+    do while (n < 0_ik)
+      pos = pos - 1
+      buffer(pos:pos) = numbers(mod(n, 10_ik))
+      n = n/10_ik
+    end do
+
+    if (val < 0_ik) then
+      pos = pos - 1
+      buffer(pos:pos) = '-'
+    end if
+
+    string = buffer(pos:)
+  end function integer_i1_to_string
+
+
+  pure function integer_i2_to_string(val) result(string)
+    integer, parameter :: ik = i2
+    !> Integer value to create string from
+    integer(ik), intent(in) :: val
+    !> String representation of integer
+    character(len=:), allocatable :: string
+
+    integer, parameter :: buffer_len = range(val)+2
+    character(len=buffer_len) :: buffer
+    integer :: pos
+    integer(ik) :: n
+    character(len=1), parameter :: numbers(-9:0) = &
+      ["9", "8", "7", "6", "5", "4", "3", "2", "1", "0"]
+
+    if (val == 0_ik) then
+      string = numbers(0)
+      return
+    end if
+
+    n = sign(val, -1_ik)
+    buffer = ""
+    pos = buffer_len + 1
+    do while (n < 0_ik)
+      pos = pos - 1
+      buffer(pos:pos) = numbers(mod(n, 10_ik))
+      n = n/10_ik
+    end do
+
+    if (val < 0_ik) then
+      pos = pos - 1
+      buffer(pos:pos) = '-'
+    end if
+
+    string = buffer(pos:)
+  end function integer_i2_to_string
+
+
+  pure function integer_i4_to_string(val) result(string)
+    integer, parameter :: ik = i4
+    !> Integer value to create string from
+    integer(ik), intent(in) :: val
+    !> String representation of integer
+    character(len=:), allocatable :: string
+
+    integer, parameter :: buffer_len = range(val)+2
+    character(len=buffer_len) :: buffer
+    integer :: pos
+    integer(ik) :: n
+    character(len=1), parameter :: numbers(-9:0) = &
+      ["9", "8", "7", "6", "5", "4", "3", "2", "1", "0"]
+
+    if (val == 0_ik) then
+      string = numbers(0)
+      return
+    end if
+
+    n = sign(val, -1_ik)
+    buffer = ""
+    pos = buffer_len + 1
+    do while (n < 0_ik)
+      pos = pos - 1
+      buffer(pos:pos) = numbers(mod(n, 10_ik))
+      n = n/10_ik
+    end do
+
+    if (val < 0_ik) then
+      pos = pos - 1
+      buffer(pos:pos) = '-'
+    end if
+
+    string = buffer(pos:)
+  end function integer_i4_to_string
+
+
+  pure function integer_i8_to_string(val) result(string)
+    integer, parameter :: ik = i8
+    !> Integer value to create string from
+    integer(ik), intent(in) :: val
+    !> String representation of integer
+    character(len=:), allocatable :: string
+
+    integer, parameter :: buffer_len = range(val)+2
+    character(len=buffer_len) :: buffer
+    integer :: pos
+    integer(ik) :: n
+    character(len=1), parameter :: numbers(-9:0) = &
+      ["9", "8", "7", "6", "5", "4", "3", "2", "1", "0"]
+
+    if (val == 0_ik) then
+      string = numbers(0)
+      return
+    end if
+
+    n = sign(val, -1_ik)
+    buffer = ""
+    pos = buffer_len + 1
+    do while (n < 0_ik)
+      pos = pos - 1
+      buffer(pos:pos) = numbers(mod(n, 10_ik))
+      n = n/10_ik
+    end do
+
+    if (val < 0_ik) then
+      pos = pos - 1
+      buffer(pos:pos) = '-'
+    end if
+
+    string = buffer(pos:)
+  end function integer_i8_to_string
+
+
+  pure function real_sp_to_string(val) result(string)
+    real(sp), intent(in) :: val
+    character(len=:), allocatable :: string
+    integer, parameter :: buffer_len = 128
+    character(len=buffer_len) :: buffer
+
+    write(buffer, '(g0)') val
+    string = trim(buffer)
+
+  end function real_sp_to_string
+
+
+  pure function real_dp_to_string(val) result(string)
+    real(dp), intent(in) :: val
+    character(len=:), allocatable :: string
+    integer, parameter :: buffer_len = 128
+    character(len=buffer_len) :: buffer
+
+    write(buffer, '(g0)') val
+    string = trim(buffer)
+
+  end function real_dp_to_string
+
+
+#if WITH_XDP
+  pure function real_xdp_to_string(val) result(string)
+    real(xdp), intent(in) :: val
+    character(len=:), allocatable :: string
+    integer, parameter :: buffer_len = 128
+    character(len=buffer_len) :: buffer
+
+    write(buffer, '(g0)') val
+    string = trim(buffer)
+
+  end function real_xdp_to_string
+#endif
+
+
+#if WITH_QP
+  pure function real_qp_to_string(val) result(string)
+    real(qp), intent(in) :: val
+    character(len=:), allocatable :: string
+    integer, parameter :: buffer_len = 128
+    character(len=buffer_len) :: buffer
+
+    write(buffer, '(g0)') val
+    string = trim(buffer)
+
+  end function real_qp_to_string
+#endif
+
+
+  pure function complex_sp_to_string(val) result(string)
+    complex(sp), intent(in) :: val
+    character(len=:), allocatable :: string
+
+    string = "("//to_string(real(val))//", "//to_string(aimag(val))//")"
+
+  end function complex_sp_to_string
+
+
+  pure function complex_dp_to_string(val) result(string)
+    complex(dp), intent(in) :: val
+    character(len=:), allocatable :: string
+
+    string = "("//to_string(real(val))//", "//to_string(aimag(val))//")"
+
+  end function complex_dp_to_string
+
+
+#if WITH_XDP
+  pure function complex_xdp_to_string(val) result(string)
+    complex(xdp), intent(in) :: val
+    character(len=:), allocatable :: string
+
+    string = "("//to_string(real(val))//", "//to_string(aimag(val))//")"
+
+  end function complex_xdp_to_string
+#endif
+
+
+#if WITH_QP
+  pure function complex_qp_to_string(val) result(string)
+    complex(qp), intent(in) :: val
+    character(len=:), allocatable :: string
+
+    string = "("//to_string(real(val))//", "//to_string(aimag(val))//")"
+
+  end function complex_qp_to_string
+#endif
+
+
+  !> Clear error type after it has been handled.
+  subroutine clear_error(error)
+
+    !> Error handling
+    type(error_type), intent(inout) :: error
+
+    if (error%stat /= success) then
+      error%stat = success
+    end if
+
+    if (allocated(error%message)) then
+      deallocate(error%message)
+    end if
+
+  end subroutine clear_error
+
+
+  !> Finalizer of the error type, in case the error is not correctly cleared it will
+  !> be escalated at runtime in a fatal way
+  subroutine escalate_error(error)
+
+    !> Error handling
+    type(error_type), intent(inout) :: error
+
+    if (error%stat /= success) then
+      write(error_unit, '(a)') "[Fatal] Uncaught error"
+      if (allocated(error%message)) then
+        write(error_unit, '(a, 1x, i0, *(1x, a))') &
+          "Code:", error%stat, "Message:", error%message
+      end if
+      error stop
+    end if
+
+  end subroutine escalate_error
+
+
+
+  !> Determine whether a value is not a number
+  elemental function is_nan_sp(val) result(is_nan)
+#if WITH_IEEE_IS_NAN
+    use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
+#endif
+    !> Value to check
+    real(sp), intent(in) :: val
+    !> Value is not a number
+    logical :: is_nan
+
+#if WITH_IEEE_IS_NAN
+    is_nan = ieee_is_nan(val)
+#else
+    is_nan = .not.((val <= huge(val) .and. val >= -huge(val)) .or. abs(val) > huge(val))
+#endif
+  end function is_nan_sp
+
+  !> Determine whether a value is not a number
+  elemental function is_nan_dp(val) result(is_nan)
+#if WITH_IEEE_IS_NAN
+    use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
+#endif
+    !> Value to check
+    real(dp), intent(in) :: val
+    !> Value is not a number
+    logical :: is_nan
+
+#if WITH_IEEE_IS_NAN
+    is_nan = ieee_is_nan(val)
+#else
+    is_nan = .not.((val <= huge(val) .and. val >= -huge(val)) .or. abs(val) > huge(val))
+#endif
+  end function is_nan_dp
+
+#if WITH_XDP
+  !> Determine whether a value is not a number
+  elemental function is_nan_xdp(val) result(is_nan)
+#if WITH_IEEE_IS_NAN
+    use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
+#endif
+    !> Value to check
+    real(xdp), intent(in) :: val
+    !> Value is not a number
+    logical :: is_nan
+
+#if WITH_IEEE_IS_NAN
+    is_nan = ieee_is_nan(val)
+#else
+    is_nan = .not.((val <= huge(val) .and. val >= -huge(val)) .or. abs(val) > huge(val))
+#endif
+  end function is_nan_xdp
+#endif
+
+#if WITH_QP
+  !> Determine whether a value is not a number
+  elemental function is_nan_qp(val) result(is_nan)
+#if WITH_IEEE_IS_NAN
+    use, intrinsic :: ieee_arithmetic, only : ieee_is_nan
+#endif
+    !> Value to check
+    real(qp), intent(in) :: val
+    !> Value is not a number
+    logical :: is_nan
+
+#if WITH_IEEE_IS_NAN
+    is_nan = ieee_is_nan(val)
+#else
+    is_nan = .not.((val <= huge(val) .and. val >= -huge(val)) .or. abs(val) > huge(val))
+#endif
+  end function is_nan_qp
+#endif
+
+  !> Initialize color output
+  subroutine init_color_output(use_color)
+    !> Enable color output
+    logical, intent(in) :: use_color
+
+    color = new_color_output(use_color)
+  end subroutine init_color_output
+
+  !> Create a new colorizer object
+  function new_color_output(use_color) result(new)
+    !> Enable color output
+    logical, intent(in) :: use_color
+    !> New instance of the colorizer
+    type(color_output) :: new
+
+    type(color_code), parameter :: &
+      reset = color_code(style=0_i1), &
+      bold = color_code(style=1_i1), &
+      dim = color_code(style=2_i1), &
+      italic = color_code(style=3_i1), &
+      underline = color_code(style=4_i1), &
+      blink = color_code(style=5_i1), &
+      reverse = color_code(style=7_i1), &
+      hidden = color_code(style=8_i1)
+
+    type(color_code), parameter :: &
+      black = color_code(fg=0_i1), &
+      red = color_code(fg=1_i1), &
+      green = color_code(fg=2_i1), &
+      yellow = color_code(fg=3_i1), &
+      blue = color_code(fg=4_i1), &
+      magenta = color_code(fg=5_i1), &
+      cyan = color_code(fg=6_i1), &
+      white = color_code(fg=7_i1)
+
+    type(color_code), parameter :: &
+      bg_black = color_code(bg=0_i1), &
+      bg_red = color_code(bg=1_i1), &
+      bg_green = color_code(bg=2_i1), &
+      bg_yellow = color_code(bg=3_i1), &
+      bg_blue = color_code(bg=4_i1), &
+      bg_magenta = color_code(bg=5_i1), &
+      bg_cyan = color_code(bg=6_i1), &
+      bg_white = color_code(bg=7_i1)
+
+    if (use_color) then
+      new%reset = reset
+      new%bold = bold
+      new%dim = dim
+      new%italic = italic
+      new%underline = underline
+      new%blink = blink
+      new%reverse = reverse
+      new%hidden = hidden
+      new%black = black
+      new%red = red
+      new%green = green
+      new%yellow = yellow
+      new%blue = blue
+      new%magenta = magenta
+      new%cyan = cyan
+      new%white = white
+      new%bg_black = bg_black
+      new%bg_red = bg_red
+      new%bg_green = bg_green
+      new%bg_yellow = bg_yellow
+      new%bg_blue = bg_blue
+      new%bg_magenta = bg_magenta
+      new%bg_cyan = bg_cyan
+      new%bg_white = bg_white
+    end if
+  end function new_color_output
+
+  !> Add two escape sequences, attributes in the right value override the left value ones.
+  pure function add_color(lval, rval) result(code)
+    !> First escape code
+    type(color_code), intent(in) :: lval
+    !> Second escape code
+    type(color_code), intent(in) :: rval
+    !> Combined escape code
+    type(color_code) :: code
+  
+    code = color_code( &
+      style=merge(rval%style, lval%style, rval%style >= 0), &
+      fg=merge(rval%fg, lval%fg, rval%fg >= 0), &
+      bg=merge(rval%bg, lval%bg, rval%bg >= 0))
+  end function add_color
+  
+  !> Concatenate an escape code with a string and turn it into an actual escape sequence
+  pure function concat_color_left(lval, code) result(str)
+    !> String to add the escape code to
+    character(len=*), intent(in) :: lval
+    !> Escape sequence
+    type(color_code), intent(in) :: code
+    !> Concatenated string
+    character(len=:), allocatable :: str
+  
+    str = lval // escape_color(code)
+  end function concat_color_left
+  
+  !> Concatenate an escape code with a string and turn it into an actual escape sequence
+  pure function concat_color_right(code, rval) result(str)
+    !> String to add the escape code to
+    character(len=*), intent(in) :: rval
+    !> Escape sequence
+    type(color_code), intent(in) :: code
+    !> Concatenated string
+    character(len=:), allocatable :: str
+  
+    str = escape_color(code) // rval
+  end function concat_color_right
+  
+  !> Transform a color code into an actual ANSI escape sequence
+  pure function escape_color(code) result(str)
+    !> Color code to be used
+    type(color_code), intent(in) :: code
+    !> ANSI escape sequence representing the color code
+    character(len=:), allocatable :: str
+    character, parameter :: chars(0:9) = &
+      ["0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]
+  
+    if (anycolor(code)) then
+      str = achar(27) // "[0"  ! Always reset the style
+      if (code%style > 0 .and. code%style < 10) str = str // ";" // chars(code%style)
+      if (code%fg >= 0 .and. code%fg < 10) str = str // ";3" // chars(code%fg)
+      if (code%bg >= 0 .and. code%bg < 10) str = str // ";4" // chars(code%bg)
+      str = str // "m"
+    else
+      str = ""
+    end if
+  end function escape_color
+  
+  !> Check whether the code describes any color or is just a stub
+  pure function anycolor(code)
+    !> Escape sequence
+    type(color_code), intent(in) :: code
+    !> Any color / style is active
+    logical :: anycolor
+  
+    anycolor = code%fg >= 0 .or. code%bg >= 0 .or. code%style >= 0
+  end function anycolor
+
+end module testdrive


### PR DESCRIPTION
## Scope

This draft reconstructs the bounded GNU serial build and dependency-light unit-test foundation selected in [fork issue #49](https://github.com/jaharris87/XNet/issues/49), the [maintainer scope decision on fork issue #4](https://github.com/jaharris87/XNet/issues/4#issuecomment-5170020567), and the [recorded integration-branch clarification](https://github.com/jaharris87/XNet/issues/4#issuecomment-5170267964). It targets upstream `starkiller-astro/XNet:codex/technical-modernization`, whose initial base is `starkiller-astro/XNet:main` commit `2b5c3159d45ccbc74f2023425db3241991c2022e`; it does not target upstream `main`, merge, rebase, or replay the fork's 86-commit history.

Included:

- correct `source/Makefile` serial dependencies, public unit-test targets, and production-executable cleanup;
- add an isolated, failure-propagating GNU serial test harness;
- vendor test-drive v0.6.1 with provenance, Apache-2.0 and MIT licenses, verified bytes, and preservation attributes;
- characterize the existing `dp`, `sp`, and `i8` type model, `safe_exp()`, input-token parsing, ASCII folding, and generated filename suffixes;
- replace the old workflow job with only `serial-build-smoke` and `serial-unit-tests`, using read-only permissions, timeouts, concurrency control, and a full-SHA checkout pin;
- add minimal build, architecture, evidence-maturity, and validation-limitation documentation while preserving the upstream README's scientific references.

## Explicit exclusions

- No `i4` source correction or focused `i4 == int32` assertion; that separate bug fix is tracked in [fork issue #50](https://github.com/jaharris87/XNet/issues/50).
- No Review Record Consistency scripts, tests, job, labels, metadata, structured-review machinery, prompt library, reviewer-role policy, branch convention, or fork-incubation governance.
- No fork decision records 0001 through 0004.
- No Technical Phase 2 work, including the `xnet_constants.F90` strict-default-kind work tracked in [fork issue #51](https://github.com/jaharris87/XNet/issues/51).
- No scientific baseline, physics gate, compiler or parallel expansion, build-system modernization, source restructuring, or unrelated production-source cleanup.

## User and scientific impact

Users and maintainers gain a repeatable clean GNU serial compile/link smoke and isolated public unit-test targets whose failure status is checked. The only production-file change is to `source/Makefile`; no production Fortran source or intended scientific/numerical behavior changes. The evidence is build and dependency-light characterization only, not scientific validation or a support commitment.

## Local validation

Environment:

- macOS 26.6 (Darwin 25.6.0, arm64; build 25G72);
- GNU Fortran (Homebrew GCC 16.1.0) 16.1.0;
- GNU Make 3.81.

Production configuration:

- `CMODE=DEBUG`, `PE_ENV=GNU`;
- `MPI_MODE=OFF`, `OPENMP_MODE=OFF`, `GPU_MODE=OFF`;
- `MATRIX_SOLVER=dense`, `LAPACK_VER=NETLIB`, `EOS=STARKILLER`;
- no repository-root `XNET_DIR` export.

Effective GNU production flags from the existing Makefiles:

- generic DEBUG: `-g -Og -ggdb -ftrapv -fexceptions -Wall -Wextra -Wno-unused-variable -Wno-unused-parameter`;
- Fortran DEBUG: `-fcheck=bounds,do,mem,pointer -ffpe-trap=invalid,zero,overflow -fbacktrace -Wno-unused-dummy-argument -Wno-unused-label -Wno-maybe-uninitialized`;
- F90: `-cpp -fdefault-real-8 -fdefault-double-8 -fimplicit-none -fallow-argument-mismatch -ffree-line-length-none`;
- the existing GNU `OPENMP_MODE=OFF` branch contributes `-lgomp`.

Exact clean build:

```bash
make -C source clean
make -C source -j2 \
  CMODE=DEBUG PE_ENV=GNU \
  MPI_MODE=OFF OPENMP_MODE=OFF GPU_MODE=OFF \
  MATRIX_SOLVER=dense LAPACK_VER=NETLIB EOS=STARKILLER \
  xnet net_setup xnse
```

Result: passed; `source/xnet`, `source/net_setup`, and `source/xnse` compiled, linked, and were executable. The build emitted existing production-source compiler warnings; no scientific case was executed.

Other checks:

- `make -C source test_unit` — passed all 8 dependency-light tests.
- `make -C source test_unit_selfcheck` — passed; the deliberate fixture returned nonzero directly and through the nested Make target, while the public self-check returned zero.
- `make -C source -j2 test_unit test_unit_selfcheck` — passed concurrently from separate build directories.
- `make -C source clean` followed by explicit absence checks — removed all named production executables covered by the clean rule.
- `git diff --check upstream/main...HEAD` — passed.
- Workflow YAML parsed with exactly `serial-build-smoke` and `serial-unit-tests`.
- Official `test-drive-0.6.1.tar.xz` SHA-256: `04452f0ca631bcb19c7cb937961457e17710d9c883deeee3c56e128e464b750f`.
- Extracted and vendored `src/testdrive.F90` SHA-256: `97838a7042c2f9895c9e5fea01b7628247a0347be57ff742794513ee34a0510f`.
- `actions/checkout` pin `3d3c42e5aac5ba805825da76410c181273ba90b1` was verified as the v7.0.1 release commit.
- Final path audit confirmed that `xnet_types.F90`, `xnet_constants.F90`, review-record automation, fork governance, decision records, and issue #51 work are absent.

## Evidence limitations

Local evidence covers one macOS arm64 GNU compiler/toolchain and the exact serial dense/NETLIB/STARKILLER configuration above. The GitHub Actions jobs add Ubuntu GNU build/test characterization when they complete. This PR does not characterize MPI, OpenMP, GPU, sparse solvers, other EOS selections, other compilers, or other platforms. It does not run a trusted end-to-end scientific comparison; the legacy numerical driver remains outside the required gates because mismatches do not reliably propagate failure and currently exercised trusted reference outputs are not tracked.

## Review needs

Please review the bounded submission for:

- software scope and maintainability;
- test behavior and failure propagation;
- build correctness, dependency provenance, byte preservation, and license inclusion;
- workflow permissions, triggers, action pin, concurrency, and untrusted-PR safety;
- documentation accuracy and evidence language.

Interfaces/data, parallel, science, and numerics review are not expected unless the diff expands.
