### PR TITLE
Fix xnet_types i4 kind width

### DIFF
--- a/doc/validation-plan.md
+++ b/doc/validation-plan.md
@@ -49,7 +49,7 @@ of correctness.
 | Item | Category | Maturity | Evidence | Configuration | Automation | Limitation |
 | --- | --- | --- | --- | --- | --- | --- |
 | Test-drive pass/fail propagation | Runner self-test | characterized | Expected process status; nested Make target observes failure | GNU Fortran, serial | `serial-unit-tests` | Runner behavior only |
-| `dp`, `sp`, and `i8` kind/storage contracts | Unit | characterized | `iso_fortran_env` and `storage_size` | GNU Fortran, serial | `serial-unit-tests` | Existing type model only |
+| `dp`, `sp`, `i4`, and `i8` kind/storage contracts | Unit | characterized | `iso_fortran_env` and `storage_size` | GNU Fortran, serial | `serial-unit-tests` | Exact kind/storage bug-fix characterization only |
 | Scalar/vector `safe_exp()` ordinary and clamped behavior | Unit | characterized | Intrinsic `exp`, clamp parameters, IEEE finite check, epsilon-scaled comparisons | GNU Fortran, serial | `serial-unit-tests` | Dependency-light routine behavior only |
 | Double-precision blank/tab numeric token parsing | Unit | characterized | Literal values after `replace_tabs()` and zero with `pos = 0` for exhausted input | GNU Fortran, serial | `serial-unit-tests` | Input-token behavior only |
 | ASCII case folding before abundance-name lookup | Characterization | characterized | Exact `Fe56` to `fe56` result from `string_lc()` | GNU Fortran, serial | `serial-unit-tests` | ASCII example only; not a locale, Unicode, file, or lookup-path claim |

--- a/source/xnet_types.F90
+++ b/source/xnet_types.F90
@@ -10,7 +10,7 @@ Module xnet_types
   !-------------------------------------------------------------------------------------------------
   Use, Intrinsic :: iso_fortran_env, Only: int32, int64, real32, real64, real128
   Implicit None
-  Integer, Parameter :: i4 = int64   ! 32-bit integer
+  Integer, Parameter :: i4 = int32   ! 32-bit integer
   Integer, Parameter :: i8 = int64   ! 64-bit integer
   Integer, Parameter :: sp = real32  ! Single precision
   Integer, Parameter :: dp = real64  ! Double precision

--- a/tests/unit/test_types.F90
+++ b/tests/unit/test_types.F90
@@ -1,7 +1,7 @@
 Module test_types
-  Use, Intrinsic :: iso_fortran_env, Only: int64, real32, real64
+  Use, Intrinsic :: iso_fortran_env, Only: int32, int64, real32, real64
   Use testdrive, Only: check, error_type, new_unittest, unittest_type
-  Use xnet_types, Only: dp, i8, sp
+  Use xnet_types, Only: dp, i4, i8, sp
   Implicit None
   Private
 
@@ -25,6 +25,8 @@ Contains
     If ( Allocated(error) ) Return
     Call check(error, sp == real32, "sp must equal iso_fortran_env real32")
     If ( Allocated(error) ) Return
+    Call check(error, i4 == int32, "i4 must equal iso_fortran_env int32")
+    If ( Allocated(error) ) Return
     Call check(error, i8 == int64, "i8 must equal iso_fortran_env int64")
   End Subroutine test_kind_values
 
@@ -34,6 +36,8 @@ Contains
     Call check(error, Storage_Size(0.0_dp) == 64, "real(dp) must occupy 64 bits")
     If ( Allocated(error) ) Return
     Call check(error, Storage_Size(0.0_sp) == 32, "real(sp) must occupy 32 bits")
+    If ( Allocated(error) ) Return
+    Call check(error, Storage_Size(0_i4) == 32, "integer(i4) must occupy 32 bits")
     If ( Allocated(error) ) Return
     Call check(error, Storage_Size(0_i8) == 64, "integer(i8) must occupy 64 bits")
   End Subroutine test_storage_sizes


### PR DESCRIPTION
## Summary

`xnet_types` publicly described `i4` as a 32-bit integer kind but erroneously bound it to `iso_fortran_env::int64`. This clear public contract bug fix changes that one alias to `int32`, retains `i8 = int64`, and adds exact kind/storage assertions. The observable result is that `integer(i4)` changes from 64-bit to 32-bit storage; downstream code using the alias must rebuild, and persisted, binary, or interoperable data layouts that relied on the erroneous width must be reassessed or use `i8` when 64 bits are required.

Context: [fork issue #50](https://github.com/jaharris87/XNet/issues/50) and [fork integration tracker #4](https://github.com/jaharris87/XNet/issues/4). These links record the fork work; this PR does not claim to close issues across repositories.

## Root cause and exact correction

- Root cause: `i4` was assigned `int64` even though the public name and adjacent comment specify a 32-bit integer.
- Correction: change only `i4 = int64` to `i4 = int32` in `source/xnet_types.F90`.
- Tests: assert `i4 == int32` and 32-bit storage while retaining the existing `i8 == int64` and 64-bit storage assertions.
- Inventory: update only the existing type-contract row to include the bounded `i4` bug-fix characterization.

## Test-first evidence

On exact staging base `6afe130fca6e10f6dbdd9400aff8b204c860d337`, I first added the focused assertions while leaving production `i4 = int64`. `make -C source test_unit` exited 2: `i4 must equal iso_fortran_env int32` and `integer(i4) must occupy 32 bits`; every unrelated unit case passed. After the one-line source correction, the same target passed both type cases. The expected kind, test semantics, and implementation change were therefore not changed together.

## Exact validation

Environment: GNU Fortran (Homebrew GCC 16.1.0) 16.1.0; GNU Make 3.81; macOS; serial build. The production DEBUG build used the Makefile's GNU flags, including `-g -Og -ggdb -ftrapv -fexceptions -Wall -Wextra -fcheck=bounds,do,mem,pointer -ffpe-trap=invalid,zero,overflow -fbacktrace -cpp -fdefault-real-8 -fdefault-double-8 -fimplicit-none -fallow-argument-mismatch -ffree-line-length-none`. The isolated unit harness used `-g -Og -cpp -fimplicit-none -fallow-argument-mismatch -fdefault-real-8 -fdefault-double-8 -ffree-line-length-none`.

```text
make -C source clean
make -C source -j2 CMODE=DEBUG PE_ENV=GNU MPI_MODE=OFF OPENMP_MODE=OFF GPU_MODE=OFF MATRIX_SOLVER=dense LAPACK_VER=NETLIB EOS=STARKILLER xnet net_setup xnse
make -C source test_unit
make -C source test_unit_selfcheck
git diff --check
```

All commands passed. `xnet`, `net_setup`, and `xnse` compiled and linked. The normal and self-check public targets also passed when launched simultaneously as separate processes, confirming their isolated build directories. The self-check's deliberate failing fixture returned nonzero and Make propagated that failure as expected. A focused probe built with the unit-harness flags reported:

```text
i4_eq_int32=T
i4_storage_bits=32
i8_eq_int64=T
i8_storage_bits=64
```

The final diff is 3 files, 8 insertions, and 4 deletions: the one-line source correction, focused existing-harness assertions/imports, and one existing inventory-row replacement. `git diff --check` passed, and a targeted source check found no production import/declaration using the public `i4` alias outside `xnet_types`.

## Evidence limits and exclusions

This is GNU/macOS serial build and exact kind/storage evidence, not non-GNU, MPI, OpenMP, GPU, external-consumer, persisted-data, runtime, numerical, or scientific validation. The clean build emitted pre-existing warnings in unrelated source; this PR does not address them.

Excluded: other kind aliases or integer declarations, compatibility shims, binary-format features, broad migration documentation, source/comment cleanup, decision records, governance or review automation, strict-default-kind constants work, and every other Technical Phase 2 change.

## Review needs

- Interfaces/data: confirm the corrected public kind and direct downstream/data-layout consequence.
- Tests: confirm the red/green isolation and exact kind/storage assertions.
- Software: confirm the bounded implementation and inventory scope.
