### PR TITLE
Make xnet_constants expressions explicit real(dp)

### DIFF
--- a/doc/validation-plan.md
+++ b/doc/validation-plan.md
@@ -50,6 +50,7 @@ of correctness.
 | --- | --- | --- | --- | --- | --- | --- |
 | Test-drive pass/fail propagation | Runner self-test | characterized | Expected process status; nested Make target observes failure | GNU Fortran, serial | `serial-unit-tests` | Runner behavior only |
 | `dp`, `sp`, `i4`, and `i8` kind/storage contracts | Unit | characterized | `iso_fortran_env` and `storage_size` | GNU Fortran, serial | `serial-unit-tests` | Exact kind/storage bug-fix characterization only |
+| `real(dp)` evaluation of representative numerical and physical constants | Unit | characterized | Fortran kind semantics and the existing `third`, `ln_2`, and `clt` expressions and values | GNU Fortran, serial, ordinary default real kind; isolated `xnet_types` and `xnet_constants` compile | `serial-unit-tests` | Portability and implementation-correctness characterization only; not a scientific validation or update of physical values. |
 | Scalar/vector `safe_exp()` ordinary and clamped behavior | Unit | characterized | Intrinsic `exp`, clamp parameters, IEEE finite check, epsilon-scaled comparisons | GNU Fortran, serial | `serial-unit-tests` | Dependency-light routine behavior only |
 | Double-precision blank/tab numeric token parsing | Unit | characterized | Literal values after `replace_tabs()` and zero with `pos = 0` for exhausted input | GNU Fortran, serial | `serial-unit-tests` | Input-token behavior only |
 | ASCII case folding before abundance-name lookup | Characterization | characterized | Exact `Fe56` to `fe56` result from `string_lc()` | GNU Fortran, serial | `serial-unit-tests` | ASCII example only; not a locale, Unicode, file, or lookup-path claim |
@@ -79,9 +80,17 @@ Run the isolated unit and runner self-check targets with:
 ```bash
 make -C source test_unit
 make -C source test_unit_selfcheck
+make -C tests strict_kind
 ```
 
 Each unit command begins from a clean dedicated directory under
 `tests/build/`, so the targets can run concurrently without sharing compiler
-artifacts. The self-check deliberately runs a failing fixture through a nested
-Make target and succeeds only when that target returns nonzero.
+artifacts. `test_unit` runs both the promoted-default-real normal suite and the
+isolated strict-kind constants check. The direct `strict_kind` command compiles
+only vendored test-drive, `xnet_types.F90`, `xnet_constants.F90`, and the test
+program with `-g -Og -cpp -fimplicit-none -fallow-argument-mismatch
+-ffree-line-length-none`; it deliberately omits `-fdefault-real-8` and
+`-fdefault-double-8`.
+
+The self-check deliberately runs a failing fixture through a nested Make target
+and succeeds only when that target returns nonzero.

--- a/source/xnet_constants.F90
+++ b/source/xnet_constants.F90
@@ -12,48 +12,49 @@ Module xnet_constants
   Implicit None
 
   ! Some commonly used fractions and logarithms
-  Real(dp), Parameter :: third   = 1.0 / 3.0
-  Real(dp), Parameter :: two3rd  = 2.0 / 3.0
-  Real(dp), Parameter :: four3rd = 4.0 / 3.0
-  Real(dp), Parameter :: five3rd = 5.0 / 3.0
-  Real(dp), Parameter :: log_e   = log10(exp(1.0))
-  Real(dp), Parameter :: ln_2    = log(2.0)
-  Real(dp), Parameter :: ln_10   = log(10.0)
+  Real(dp), Parameter :: third   = 1.0_dp / 3.0_dp
+  Real(dp), Parameter :: two3rd  = 2.0_dp / 3.0_dp
+  Real(dp), Parameter :: four3rd = 4.0_dp / 3.0_dp
+  Real(dp), Parameter :: five3rd = 5.0_dp / 3.0_dp
+  Real(dp), Parameter :: log_e   = log10(exp(1.0_dp))
+  Real(dp), Parameter :: ln_2    = log(2.0_dp)
+  Real(dp), Parameter :: ln_10   = log(10.0_dp)
 
   ! 71 digits of pi (256-bit precision)
-  Real(dp), Parameter :: pi      = 3.1415926535897932384626433832795028841971693993751058209749445923078164
+  Real(dp), Parameter :: pi      = 3.1415926535897932384626433832795028841971693993751058209749445923078164_dp
   Real(dp), Parameter :: pi2     = pi * pi
 
   ! Fundamental constants (CODATA recommended 2014 values)
   ! P. J. Mohr, D. B. Newell, and B. N. Taylor, Rev. Mod. Phys. 88, 035009 (2016)
   ! http://physics.nist.gov/cuu/Constants/Table/allascii.txt
-  Real(dp), Parameter :: clt     = 2.99792458e+10   ! Speed of light in vacuum [cm s^{-1}]
-  Real(dp), Parameter :: hbar    = 6.582119514e-22  ! Plank constants, reduced [MeV s]
-  Real(dp), Parameter :: avn     = 6.022140857e+23  ! Avogadro constant [mol^{-1}]
-  Real(dp), Parameter :: bok     = 8.6173303e-02    ! Boltzmann constant [MeV GK^{-1}]
-  Real(dp), Parameter :: epmev   = 1.6021766208e-06 ! MeV to erg conversion factor [erg MeV^{-1}]
-  Real(dp), Parameter :: m_e     = 0.5109989461     ! Electron mass [MeV c^{-2}]
-  Real(dp), Parameter :: m_n     = 939.5654133      ! Neutron mass [MeV c^{-2}]
-  Real(dp), Parameter :: m_p     = 938.2720813      ! Proton mass [MeV c^{-2}]
+  Real(dp), Parameter :: clt     = 2.99792458e+10_dp   ! Speed of light in vacuum [cm s^{-1}]
+  Real(dp), Parameter :: hbar    = 6.582119514e-22_dp  ! Plank constants, reduced [MeV s]
+  Real(dp), Parameter :: avn     = 6.022140857e+23_dp  ! Avogadro constant [mol^{-1}]
+  Real(dp), Parameter :: bok     = 8.6173303e-02_dp    ! Boltzmann constant [MeV GK^{-1}]
+  Real(dp), Parameter :: epmev   = 1.6021766208e-06_dp ! MeV to erg conversion factor [erg MeV^{-1}]
+  Real(dp), Parameter :: m_e     = 0.5109989461_dp     ! Electron mass [MeV c^{-2}]
+  Real(dp), Parameter :: m_n     = 939.5654133_dp      ! Neutron mass [MeV c^{-2}]
+  Real(dp), Parameter :: m_p     = 938.2720813_dp      ! Proton mass [MeV c^{-2}]
   Real(dp), Parameter :: ele_en  = m_e              ! Electron mass [MeV c^{-2}]
-  Real(dp), Parameter :: asig    = 8.563456e+31     ! Radiation constant [cm^{-3} MeV^{-3}]
+  Real(dp), Parameter :: asig    = 8.563456e+31_dp     ! Radiation constant [cm^{-3} MeV^{-3}]
 
   ! Some derived constants
-  Real(dp), Parameter :: amu     = 1.0/(avn*epmev)      ! = 1.036426957e-18 ! Atomic mass unit [MeV]
+  Real(dp), Parameter :: amu     = 1.0_dp/(avn*epmev)   ! = 1.036426957e-18 ! Atomic mass unit [MeV]
   Real(dp), Parameter :: m_u     = amu * clt**2         ! = 931.4940954     ! Atomic mass unit [MeV c^{-2}]
-  Real(dp), Parameter :: e2      = 1.0e-28*epmev*clt**2 ! = 1.439964533e-13 ! (elementary charge)^2 [MeV^2]
+  Real(dp), Parameter :: e2      = 1.0e-28_dp*epmev*clt**2 ! = 1.439964533e-13 ! (elementary charge)^2 [MeV^2]
   Real(dp), Parameter :: emass   = m_e / clt**2         ! Electron mass [MeV]
 
   ! Screening factors from Table 4 of Graboske+ (1973)
-  Real(dp), Parameter   :: bw = 1.0,  kbw = 0.5            ! Weak screening parameters
-  Real(dp), Parameter   :: bi = 0.86, kbi = 0.38           ! Intermediate screening parmaeters
-  Real(dp), Parameter   :: bip1 = 1.86                     ! bi + 1
-  Real(dp), Parameter   :: thbim1 = 1.58                   ! 3*bi - 1
-  Real(dp), Parameter   :: thbim2 = 0.58                   ! 3*bi - 2
-  Real(dp), Parameter   :: twm2bi = 0.28                   ! 2 - 2*bi
+  Real(dp), Parameter   :: bw = 1.0_dp,  kbw = 0.5_dp      ! Weak screening parameters
+  Real(dp), Parameter   :: bi = 0.86_dp, kbi = 0.38_dp     ! Intermediate screening parmaeters
+  Real(dp), Parameter   :: bip1 = 1.86_dp                  ! bi + 1
+  Real(dp), Parameter   :: thbim1 = 1.58_dp                ! 3*bi - 1
+  Real(dp), Parameter   :: thbim2 = 0.58_dp                ! 3*bi - 2
+  Real(dp), Parameter   :: twm2bi = 0.28_dp                ! 2 - 2*bi
 
   ! Strong screening fitting coefficients from DeWitt & Slattery (2003), Eq. 4:
   !   f(gamma) = a*gamma + (1/s)*b*gamma^s + c*ln(gamma) + d
-  Real(dp), Parameter   :: cds(5) = (/ -0.899172, 0.602249, -0.274823, -1.401915, 0.3230064 /)
+  Real(dp), Parameter   :: cds(5) = (/ -0.899172_dp, 0.602249_dp, -0.274823_dp, &
+                                       -1.401915_dp, 0.3230064_dp /)
 
 End Module xnet_constants

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -6,15 +6,19 @@ BUILD_ROOT := build
 BUILD_DIR ?= $(BUILD_ROOT)
 UNIT_BUILD_DIR := $(BUILD_ROOT)/unit
 SELFCHECK_BUILD_DIR := $(BUILD_ROOT)/selfcheck
+STRICT_KIND_BUILD_DIR := $(BUILD_ROOT)/strict-kind
 MOD_DIR := $(BUILD_DIR)/mod
 UNIT_EXE := $(BUILD_DIR)/unit_tests
 FAILURE_EXE := $(BUILD_DIR)/failure_fixture
+STRICT_KIND_EXE := $(BUILD_DIR)/strict_kind_tests
 
 SOURCE_DIR := ../source
 VENDOR_DIR := vendor/test-drive-v0.6.1
 
 F90FLAGS = -g -Og -cpp -fimplicit-none -fallow-argument-mismatch \
            -fdefault-real-8 -fdefault-double-8 -ffree-line-length-none
+STRICT_KIND_F90FLAGS := -g -Og -cpp -fimplicit-none \
+                        -fallow-argument-mismatch -ffree-line-length-none
 COMPILE_FLAGS := $(F90FLAGS) -J$(MOD_DIR) -I$(MOD_DIR) -I$(SOURCE_DIR)
 
 PRODUCTION_OBJECTS := \
@@ -31,16 +35,30 @@ UNIT_OBJECTS := \
 	$(BUILD_DIR)/test_name_ordered.o \
 	$(BUILD_DIR)/unit_test_main.o
 FAILURE_OBJECT := $(BUILD_DIR)/failure_fixture.o
+STRICT_KIND_OBJECTS := \
+	$(TESTDRIVE_OBJECT) \
+	$(BUILD_DIR)/xnet_types.o \
+	$(BUILD_DIR)/xnet_constants.o \
+	$(BUILD_DIR)/test_constants.o
 
-.PHONY: test run_unit selfcheck run_selfcheck failure_fixture_status \
+.PHONY: test run_unit strict_kind run_strict_kind selfcheck run_selfcheck failure_fixture_status \
 	clean clean_build
 
 test:
 	@$(MAKE) --no-print-directory clean_build BUILD_DIR="$(UNIT_BUILD_DIR)"
 	@$(MAKE) --no-print-directory run_unit BUILD_DIR="$(UNIT_BUILD_DIR)"
+	@$(MAKE) --no-print-directory strict_kind
 
 run_unit: $(UNIT_EXE)
 	$(UNIT_EXE)
+
+strict_kind:
+	@$(MAKE) --no-print-directory clean_build BUILD_DIR="$(STRICT_KIND_BUILD_DIR)"
+	@$(MAKE) --no-print-directory run_strict_kind \
+	  BUILD_DIR="$(STRICT_KIND_BUILD_DIR)" F90FLAGS="$(STRICT_KIND_F90FLAGS)"
+
+run_strict_kind: $(STRICT_KIND_EXE)
+	$(STRICT_KIND_EXE)
 
 selfcheck:
 	@$(MAKE) --no-print-directory clean_build BUILD_DIR="$(SELFCHECK_BUILD_DIR)"
@@ -68,6 +86,9 @@ $(UNIT_EXE): $(TESTDRIVE_OBJECT) $(PRODUCTION_OBJECTS) $(UNIT_OBJECTS)
 	$(FC) $(F90FLAGS) -o $@ $^
 
 $(FAILURE_EXE): $(TESTDRIVE_OBJECT) $(FAILURE_OBJECT)
+	$(FC) $(F90FLAGS) -o $@ $^
+
+$(STRICT_KIND_EXE): $(STRICT_KIND_OBJECTS)
 	$(FC) $(F90FLAGS) -o $@ $^
 
 $(BUILD_DIR) $(MOD_DIR):
@@ -120,11 +141,18 @@ $(BUILD_DIR)/failure_fixture.o: selfcheck/failure_fixture.F90 \
 		$(TESTDRIVE_OBJECT) | $(BUILD_DIR) $(MOD_DIR)
 	$(FC) $(COMPILE_FLAGS) -c $< -o $@
 
+$(BUILD_DIR)/test_constants.o: unit/test_constants.F90 \
+		$(TESTDRIVE_OBJECT) $(BUILD_DIR)/xnet_types.o \
+		$(BUILD_DIR)/xnet_constants.o | $(BUILD_DIR) $(MOD_DIR)
+	$(FC) $(COMPILE_FLAGS) -c $< -o $@
+
 clean:
 	@$(MAKE) --no-print-directory clean_build BUILD_DIR="$(BUILD_ROOT)"
 	@$(MAKE) --no-print-directory clean_build BUILD_DIR="$(UNIT_BUILD_DIR)"
 	@$(MAKE) --no-print-directory clean_build BUILD_DIR="$(SELFCHECK_BUILD_DIR)"
+	@$(MAKE) --no-print-directory clean_build BUILD_DIR="$(STRICT_KIND_BUILD_DIR)"
 
 clean_build:
-	rm -f $(BUILD_DIR)/*.o $(BUILD_DIR)/unit_tests $(BUILD_DIR)/failure_fixture
+	rm -f $(BUILD_DIR)/*.o $(BUILD_DIR)/unit_tests $(BUILD_DIR)/failure_fixture \
+	  $(BUILD_DIR)/strict_kind_tests
 	rm -f $(MOD_DIR)/*.mod $(MOD_DIR)/*.smod

--- a/tests/unit/test_constants.F90
+++ b/tests/unit/test_constants.F90
@@ -1,0 +1,50 @@
+Module test_constants
+  Use testdrive, Only: check, error_type, new_unittest, unittest_type
+  Use xnet_constants, Only: clt, ln_2, third
+  Use xnet_types, Only: dp
+  Implicit None
+  Private
+
+  Public :: collect_constants
+
+Contains
+
+  Subroutine collect_constants(tests)
+    Type(unittest_type), Allocatable, Intent(out) :: tests(:)
+
+    tests = [new_unittest("explicit real(dp) constants", test_dp_constants)]
+  End Subroutine collect_constants
+
+  Subroutine test_dp_constants(error)
+    Type(error_type), Allocatable, Intent(out) :: error
+
+    Call check(error, Kind(1.0) /= dp, &
+      "strict-kind test must preserve the compiler default real kind")
+    If ( Allocated(error) ) Return
+
+    Call check(error, third == 1.0_dp / 3.0_dp, &
+      "third must be evaluated using real(dp) division")
+    If ( Allocated(error) ) Return
+
+    Call check(error, ln_2 == Log(2.0_dp), &
+      "ln_2 must select the real(dp) logarithm")
+    If ( Allocated(error) ) Return
+
+    Call check(error, clt == 2.99792458e+10_dp, &
+      "clt must preserve its real(dp) literal value")
+  End Subroutine test_dp_constants
+
+End Module test_constants
+
+Program strict_kind_constants
+  Use, Intrinsic :: iso_fortran_env, Only: error_unit
+  Use test_constants, Only: collect_constants
+  Use testdrive, Only: run_testsuite
+  Implicit None
+
+  Integer :: stat
+
+  stat = 0
+  Call run_testsuite(collect_constants, error_unit, stat)
+  If ( stat > 0 ) Error Stop 1
+End Program strict_kind_constants


### PR DESCRIPTION
## Provenance

This is the bounded upstream adaptation of the accepted fork work in [jaharris87/XNet issue #51](https://github.com/jaharris87/XNet/issues/51) and merged [jaharris87/XNet PR #53](https://github.com/jaharris87/XNet/pull/53). It ports source commits `f212e26689b61dcea690b46e8b0867548caba3b1` and `585d775b0436f1af32094ef54d41f2846948fa71` onto cumulative staging base `416e0013fa6247886ab920dd31289cd77ab4fabe`.

This PR targets `codex/technical-modernization` only. Upstream `main` is not a target.

## Summary

- make real constant expressions in `source/xnet_constants.F90` explicitly evaluate as `real(dp)`, including fraction operands, generic-intrinsic arguments, physical literals, and strong-screening constructor elements;
- add one isolated test-drive procedure covering `third`, `ln_2`, and `clt` under ordinary GNU default kinds;
- integrate the dedicated strict-kind target into the public unit target; and
- add the bounded characterization to the existing staging validation inventory.

The declared decimal physical values and formulas are unchanged. Reference answers, tolerances, and reference data are unchanged.

## Root cause and representative failure modes

A `real(dp)` declaration converts an initializer result but does not retroactively change the kind used to evaluate that initializer. Under ordinary compiler defaults, the previous source therefore lost precision before assignment in representative ways:

- `third = 1.0 / 3.0` performed default-real division;
- `ln_2 = log(2.0)` selected the default-real generic intrinsic;
- `clt = 2.99792458e+10` rounded a non-exact physical literal at default real; and
- `cds` used a default-real array constructor before conversion.

The patch suffixes the remaining real literals systematically so the module contract is explicit. It does not claim every previous unsuffixed literal narrowed: exact literals in mixed-`dp` operations were promoted for the operation, and expressions already composed only from `dp` parameters already evaluated at `dp`.

Consumers compiling this module with ordinary default real may observe corrected low bits and propagated downstream numerical-output differences. That is the intended portability and implementation-correctness consequence, not a physical-value or scientific-data change.

## Strict-kind isolation

The dedicated command is:

```bash
make -C tests strict_kind
```

It compiles only vendored test-drive v0.6.1, `xnet_types.F90`, `xnet_constants.F90`, and `test_constants.F90` with:

```text
-g -Og -cpp -fimplicit-none -fallow-argument-mismatch -ffree-line-length-none
```

The target deliberately omits `-fdefault-real-8` and `-fdefault-double-8`, uses its own clean build directory, and asserts that the compiler default real kind differs from `dp`. One test-drive procedure exercises the three representative failure modes.

## Red/green evidence

Compiler and host: GNU Fortran 16.1.0 (Homebrew GCC 16.1.0), Darwin 26.6 arm64.

- Red commit `b29ea24`, with staging production source unchanged: `make -C tests strict_kind` exited 2 with `third must be evaluated using real(dp) division`. The compile command contained neither default-real promotion flag.
- Green commit `c65ad85`: the identical command exited 0 and the single `explicit real(dp) constants` test passed.

## Validation

Passed locally on `c65ad85`:

- `make -C tests strict_kind`;
- `make -C source test_unit` (promoted-default suite plus integrated strict-kind check);
- `make -C source test_unit_selfcheck` (both deliberate failure paths observed and propagated);
- `make -C source clean`;
- `make -C source -j2 CMODE=DEBUG PE_ENV=GNU MPI_MODE=OFF OPENMP_MODE=OFF GPU_MODE=OFF MATRIX_SOLVER=dense LAPACK_VER=NETLIB EOS=STARKILLER xnet net_setup xnse` (all three executables compiled and linked);
- `git diff --check 416e0013fa6247886ab920dd31289cd77ab4fabe...HEAD`; and
- exact four-file scope verification.

Production and test artifacts were cleaned afterward. Existing production warnings outside the changed module remain; the exact build exited 0.

## Configuration limits and non-goals

The production smoke is build-characterization evidence only for GNU Fortran, debug, serial, dense, vendored NETLIB, and STARKILLER. This PR does not characterize other compilers, MPI, OpenMP, GPU, sparse solvers, other EOS choices, or production-wide ordinary-default-kind compilation.

It does not update CODATA or screening values, select scientific reference answers, remove production default-real promotion flags, modernize the build, restructure modules, add a compiler matrix or legacy end-to-end gate, add migration guidance, import fork governance or review automation, add decision records, or target/modify upstream `main`. This is portability and implementation-correctness characterization, not scientific validation.

## Files changed

- `source/xnet_constants.F90`
- `tests/Makefile`
- `tests/unit/test_constants.F90`
- `doc/validation-plan.md`
