### PR TITLE
Validate fd0h order-zero identity at five moderate inputs

### DIFF
--- a/doc/validation-plan.md
+++ b/doc/validation-plan.md
@@ -51,6 +51,7 @@ of correctness.
 | Test-drive pass/fail propagation | Runner self-test | characterized | Expected process status; nested Make target observes failure | GNU Fortran, serial | `serial-unit-tests` | Runner behavior only |
 | `dp`, `sp`, `i4`, and `i8` kind/storage contracts | Unit | characterized | `iso_fortran_env` and `storage_size` | GNU Fortran, serial | `serial-unit-tests` | Exact kind/storage bug-fix characterization only |
 | `real(dp)` evaluation of representative numerical and physical constants | Unit | characterized | Fortran kind semantics and the existing `third`, `ln_2`, and `clt` expressions and values | GNU Fortran, serial, ordinary default real kind; isolated `xnet_types` and `xnet_constants` compile | `serial-unit-tests` | Portability and implementation-correctness characterization only; not a scientific validation or update of physical values. |
+| `fd0h` order-zero identity at `eta = [-4, -1, 0, 1, 4]` | Unit analytic validation | validated | [Fukushima (2015)](https://doi.org/10.1016/j.amc.2015.03.009), equation 17; section 3.7 limits use of the direct identity, and Table 27 reports order-zero errors in `2^-53` units. The test uses `32 * EPSILON(1.0_dp)`, with Fortran `EPSILON` equal to `2^-52` in the recorded binary64 configuration, to also cover rounding in the independently evaluated intrinsic reference. | GNU Fortran, serial, normal dependency-light unit configuration | `serial-unit-tests` | Limited to these five moderate inputs; not a full approximation error envelope, FFN/EOS/network validation, compiler/project support claim, or scientific baseline. |
 | Scalar/vector `safe_exp()` ordinary and clamped behavior | Unit | characterized | Intrinsic `exp`, clamp parameters, IEEE finite check, epsilon-scaled comparisons | GNU Fortran, serial | `serial-unit-tests` | Dependency-light routine behavior only |
 | Double-precision blank/tab numeric token parsing | Unit | characterized | Literal values after `replace_tabs()` and zero with `pos = 0` for exhausted input | GNU Fortran, serial | `serial-unit-tests` | Input-token behavior only |
 | ASCII case folding before abundance-name lookup | Characterization | characterized | Exact `Fe56` to `fe56` result from `string_lc()` | GNU Fortran, serial | `serial-unit-tests` | ASCII example only; not a locale, Unicode, file, or lookup-path claim |
@@ -59,8 +60,10 @@ of correctness.
 | Legacy problem execution paths | Smoke/characterization | available | Inputs and scripts in `test/`; no tracked trusted results for exercised cases | Multiple historical configurations | Not a required gate | Historical use reported |
 | Legacy numerical comparisons | Regression | available | Mismatches do not propagate failure; reference provenance unavailable | Historical | Not a required gate | Not trusted as a scientific gate |
 
-These rows characterize only the exact configurations exercised by recorded
-local or CI runs. They are not scientific validation or support commitments.
+Except for the `fd0h` row, these rows characterize only the exact configurations
+exercised by recorded local or CI runs. The `fd0h` row validates only the stated
+analytic identity at its five moderate inputs. No row is a broad/full-domain/
+network scientific validation or support commitment.
 
 ## Commands
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -23,6 +23,7 @@ COMPILE_FLAGS := $(F90FLAGS) -J$(MOD_DIR) -I$(MOD_DIR) -I$(SOURCE_DIR)
 
 PRODUCTION_OBJECTS := \
 	$(BUILD_DIR)/xnet_types.o \
+	$(BUILD_DIR)/xnet_fd.o \
 	$(BUILD_DIR)/xnet_parallel_stubs.o \
 	$(BUILD_DIR)/xnet_constants.o \
 	$(BUILD_DIR)/xnet_util.o
@@ -30,6 +31,7 @@ PRODUCTION_OBJECTS := \
 TESTDRIVE_OBJECT := $(BUILD_DIR)/testdrive.o
 UNIT_OBJECTS := \
 	$(BUILD_DIR)/test_types.o \
+	$(BUILD_DIR)/test_fd0h.o \
 	$(BUILD_DIR)/test_safe_exp.o \
 	$(BUILD_DIR)/test_input_parsing.o \
 	$(BUILD_DIR)/test_name_ordered.o \
@@ -100,6 +102,10 @@ $(BUILD_DIR)/testdrive.o: $(VENDOR_DIR)/src/testdrive.F90 | $(BUILD_DIR) $(MOD_D
 $(BUILD_DIR)/xnet_types.o: $(SOURCE_DIR)/xnet_types.F90 | $(BUILD_DIR) $(MOD_DIR)
 	$(FC) $(COMPILE_FLAGS) -c $< -o $@
 
+$(BUILD_DIR)/xnet_fd.o: $(SOURCE_DIR)/xnet_fd.F90 \
+		$(BUILD_DIR)/xnet_types.o | $(BUILD_DIR) $(MOD_DIR)
+	$(FC) $(COMPILE_FLAGS) -c $< -o $@
+
 $(BUILD_DIR)/xnet_parallel_stubs.o: $(SOURCE_DIR)/xnet_parallel_stubs.F90 \
 		$(BUILD_DIR)/xnet_types.o | $(BUILD_DIR) $(MOD_DIR)
 	$(FC) $(COMPILE_FLAGS) -c $< -o $@
@@ -118,6 +124,11 @@ $(BUILD_DIR)/test_types.o: unit/test_types.F90 \
 		$(TESTDRIVE_OBJECT) $(BUILD_DIR)/xnet_types.o | $(BUILD_DIR) $(MOD_DIR)
 	$(FC) $(COMPILE_FLAGS) -c $< -o $@
 
+$(BUILD_DIR)/test_fd0h.o: unit/test_fd0h.F90 \
+		$(TESTDRIVE_OBJECT) $(BUILD_DIR)/xnet_types.o \
+		$(BUILD_DIR)/xnet_fd.o | $(BUILD_DIR) $(MOD_DIR)
+	$(FC) $(COMPILE_FLAGS) -c $< -o $@
+
 $(BUILD_DIR)/test_safe_exp.o: unit/test_safe_exp.F90 \
 		$(TESTDRIVE_OBJECT) $(BUILD_DIR)/xnet_util.o | $(BUILD_DIR) $(MOD_DIR)
 	$(FC) $(COMPILE_FLAGS) -c $< -o $@
@@ -132,7 +143,7 @@ $(BUILD_DIR)/test_name_ordered.o: unit/test_name_ordered.F90 \
 	$(FC) $(COMPILE_FLAGS) -c $< -o $@
 
 $(BUILD_DIR)/unit_test_main.o: unit/main.F90 \
-		$(TESTDRIVE_OBJECT) $(BUILD_DIR)/test_types.o \
+		$(TESTDRIVE_OBJECT) $(BUILD_DIR)/test_types.o $(BUILD_DIR)/test_fd0h.o \
 		$(BUILD_DIR)/test_safe_exp.o $(BUILD_DIR)/test_input_parsing.o \
 		$(BUILD_DIR)/test_name_ordered.o | $(BUILD_DIR) $(MOD_DIR)
 	$(FC) $(COMPILE_FLAGS) -c $< -o $@

--- a/tests/unit/main.F90
+++ b/tests/unit/main.F90
@@ -1,6 +1,7 @@
 Program unit_test_main
   Use, Intrinsic :: iso_fortran_env, Only: error_unit
   Use testdrive, Only: new_testsuite, run_testsuite, testsuite_type
+  Use test_fd0h, Only: collect_fd0h
   Use test_input_parsing, Only: collect_input_parsing
   Use test_name_ordered, Only: collect_name_ordered
   Use test_safe_exp, Only: collect_safe_exp
@@ -12,6 +13,7 @@ Program unit_test_main
 
   suites = [ &
     new_testsuite("types", collect_types), &
+    new_testsuite("fd0h", collect_fd0h), &
     new_testsuite("safe_exp", collect_safe_exp), &
     new_testsuite("input parsing", collect_input_parsing), &
     new_testsuite("generated filename suffixes", collect_name_ordered) &

--- a/tests/unit/test_fd0h.F90
+++ b/tests/unit/test_fd0h.F90
@@ -1,0 +1,38 @@
+Module test_fd0h
+  Use testdrive, Only: check, error_type, new_unittest, unittest_type
+  Use fd, Only: fd0h
+  Use xnet_types, Only: dp
+  Implicit None
+  Private
+
+  Public :: collect_fd0h
+
+Contains
+
+  Subroutine collect_fd0h(tests)
+    Type(unittest_type), Allocatable, Intent(out) :: tests(:)
+
+    tests = [ &
+      new_unittest("exact order-zero identity", test_exact_order_zero_identity) &
+    ]
+  End Subroutine collect_fd0h
+
+  Subroutine test_exact_order_zero_identity(error)
+    Type(error_type), Allocatable, Intent(out) :: error
+    Integer :: i
+    Real(dp) :: actual, expected
+    Real(dp) :: eta(5)
+
+    eta = [-4.0_dp, -1.0_dp, 0.0_dp, 1.0_dp, 4.0_dp]
+
+    Do i = 1, Size(eta)
+      actual = fd0h(eta(i))
+      expected = Log(1.0_dp + Exp(eta(i)))
+      Call check(error, &
+        Abs(actual - expected) <= 32.0_dp * Epsilon(1.0_dp) * Abs(expected), &
+        "fd0h must agree with the exact order-zero identity")
+      If ( Allocated(error) ) Return
+    EndDo
+  End Subroutine test_exact_order_zero_identity
+
+End Module test_fd0h


### PR DESCRIPTION
## Summary

- port the accepted fork #54 `fd0h` analytic validation to the cumulative upstream technical-modernization staging branch
- exercise the order-zero identity independently as `Log(1.0_dp + Exp(eta))` at `eta = [-4, -1, 0, 1, 4]`
- compile the existing `xnet_fd.F90` module and the single new test procedure through the existing unit harness
- record the narrow validation claim and Fukushima 2015 DOI in the existing validation inventory

Provenance: https://github.com/jaharris87/XNet/issues/54. This upstream PR links that fork issue for provenance; it does not claim to close it.

## Validation claim

This validates only the order-zero identity at the five moderate inputs above. The relative comparison bound is
`32 * EPSILON(1.0_dp) * Abs(expected)`. Fukushima Table 27 reports order-zero errors in `2^-53` units, while Fortran binary64 `EPSILON(1.0_dp)` is `2^-52`; the test bound also covers rounding in the independently evaluated intrinsic reference.

## Local validation

Compiler: GNU Fortran 16.1.0 (Homebrew GCC 16.1.0).

- `make -C source test_unit` — passed, including the new `fd0h` procedure and the isolated strict-kind constants test. The normal serial unit harness used `-g -Og -cpp -fimplicit-none -fallow-argument-mismatch -fdefault-real-8 -fdefault-double-8 -ffree-line-length-none`; the strict-kind test omitted the two default-kind promotion flags.
- `make -C source test_unit_selfcheck` — passed; the deliberate fixture returned nonzero and Make propagated the failure.
- `make -C source clean` followed by `make -C source -j2 CMODE=DEBUG PE_ENV=GNU MPI_MODE=OFF OPENMP_MODE=OFF GPU_MODE=OFF MATRIX_SOLVER=dense LAPACK_VER=NETLIB EOS=STARKILLER xnet net_setup xnse` — passed. This is serial DEBUG GNU, dense solver, vendored NETLIB, STARKILLER EOS, with MPI/OpenMP/GPU disabled; it is build-characterization evidence only.
- `git diff --check` — passed.

Generated source and unit-test build artifacts were cleaned afterward.

## Non-goals

- no changes to `source/xnet_fd.F90` or `source/xnet_ffn.F90`
- no claim over a full approximation error envelope or extreme input domain
- no FFN, EOS, end-to-end network, or broad scientific validation
- no compiler/project support commitment and no scientific baseline
- no decision record, migration guide, fork governance, review automation, incubation material, or fork reference-document import
